### PR TITLE
Set users to candidate role by default

### DIFF
--- a/synapsis/src/main/java/com/soen/synapsis/appuser/Role.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/Role.java
@@ -1,6 +1,6 @@
 package com.soen.synapsis.appuser;
 
 public enum Role {
-    USER,
+    CANDIDATE,
     ADMIN
 }

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/WebSecurityConfiguration.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/WebSecurityConfiguration.java
@@ -34,7 +34,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity httpSecurity) throws Exception {
         httpSecurity.authorizeRequests()
-                .antMatchers("/privateuser").hasAuthority(Role.USER.toString())
+                .antMatchers("/privateuser").hasAuthority(Role.CANDIDATE.toString())
                 .antMatchers("/admin").hasAuthority(Role.ADMIN.toString())
                 .antMatchers("/**").permitAll()
                 .anyRequest()

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/registration/RegistrationService.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/registration/RegistrationService.java
@@ -29,7 +29,7 @@ public class RegistrationService {
                 new AppUser(request.getName(),
                         request.getPassword(),
                         request.getEmail(),
-                        Role.USER)
+                        Role.CANDIDATE)
         );
     }
 }

--- a/synapsis/src/main/resources/data.sql
+++ b/synapsis/src/main/resources/data.sql
@@ -1,6 +1,6 @@
 -- Password is 1234
 INSERT INTO app_user (name, password, email, role)
-VALUES ('Joe User', '$2a$12$5E0cSCs0SlULsDfdhsYgxObMbnAbXbIC/gge/uM5U3CjTW2/UFF8.', 'joeuser@mail.com', 'USER');
+VALUES ('Joe User', '$2a$12$5E0cSCs0SlULsDfdhsYgxObMbnAbXbIC/gge/uM5U3CjTW2/UFF8.', 'joeuser@mail.com', 'CANDIDATE');
 
 INSERT INTO app_user (name, password, email, role)
 VALUES ('Joe Admin', '$2a$12$5E0cSCs0SlULsDfdhsYgxObMbnAbXbIC/gge/uM5U3CjTW2/UFF8.', 'joeadmin@mail.com', 'ADMIN');

--- a/synapsis/src/test/java/com/soen/synapsis/integration/AppUserRepositoryTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/integration/AppUserRepositoryTest.java
@@ -28,7 +28,7 @@ class AppUserRepositoryTest {
                 "Joe User",
                 "1234",
                 email,
-                Role.USER);
+                Role.CANDIDATE);
         underTest.save(appUser);
 
         AppUser foundAppUser = underTest.findByEmail(email);

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserDetailsTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserDetailsTest.java
@@ -22,7 +22,7 @@ public class AppUserDetailsTest {
     public AppUserDetailsTest() {
         email = "joeuserdetails@mail.com";
         password = "1234";
-        role = Role.USER;
+        role = Role.CANDIDATE;
         this.appUser = new AppUser(1L, "joe", password, email, role);
 
         underTest = new AppUserDetails(appUser);

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserTest.java
@@ -23,7 +23,7 @@ class AppUserTest {
         id = 10L;
         password = "1234";
         email = "joeunittest@mail.com";
-        role = Role.USER;
+        role = Role.CANDIDATE;
         underTest = new AppUser(id, name, password, email, role);
     }
 


### PR DESCRIPTION
Use the role CANDIDATE as a default role, rather than USER.

This PR closes #17 