### PR TITLE
Allow users to register as either candidates or as companies

### DIFF
--- a/synapsis/pom.xml
+++ b/synapsis/pom.xml
@@ -15,6 +15,9 @@
     <description>A social network for professionals</description>
     <properties>
         <java.version>11</java.version>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <jacoco.version>0.8.6</jacoco.version>
     </properties>
     <dependencies>
         <dependency>
@@ -90,6 +93,37 @@
                         </exclude>
                     </excludes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/utility/Constants*</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>post-unit-test</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <!--Sets the path to the file which contains the execution data.-->
+                            <dataFile>target/jacoco.exec</dataFile>
+                            <!--Sets the output directory for the code coverage report.-->
+                            <outputDirectory>target/jacoco-ut</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/AppUserService.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/AppUserService.java
@@ -26,7 +26,7 @@ public class AppUserService {
         boolean appUserExists = appUserRepository.findByEmail(appUser.getEmail()) != null;
 
         if (appUserExists) {
-            throw new IllegalStateException("This email is already taken");
+            throw new IllegalStateException("This email is already taken.");
         }
 
         appUser.setPassword(encoder.encode(appUser.getPassword()));

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/Role.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/Role.java
@@ -2,5 +2,7 @@ package com.soen.synapsis.appuser;
 
 public enum Role {
     CANDIDATE,
-    ADMIN
+    ADMIN,
+    RECRUITER,
+    COMPANY
 }

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/WebSecurityConfiguration.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/WebSecurityConfiguration.java
@@ -1,5 +1,6 @@
 package com.soen.synapsis.appuser;
 
+import com.soen.synapsis.utility.ExcludeFromGeneratedTestReport;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,6 +33,7 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
     }
 
     @Override
+    @ExcludeFromGeneratedTestReport
     protected void configure(HttpSecurity httpSecurity) throws Exception {
         httpSecurity.authorizeRequests()
                 .antMatchers("/privateuser").hasAuthority(Role.CANDIDATE.toString())

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/registration/RegistrationController.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/registration/RegistrationController.java
@@ -53,7 +53,7 @@ public class RegistrationController {
             return response;
         }
         catch (Exception e) {
-            model.addAttribute("error", "There was an error registering you. Ensure the entered email is valid.");
+            model.addAttribute("error", "There was an error registering you. " + e.getMessage());
             return register(model);
         }
     }

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/registration/RegistrationRequest.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/registration/RegistrationRequest.java
@@ -1,17 +1,22 @@
 package com.soen.synapsis.appuser.registration;
 
+import com.soen.synapsis.appuser.Role;
+
 public class RegistrationRequest {
     private String name;
     private String email;
     private String password;
+    private Role role;
 
     public RegistrationRequest() {
+        role = Role.CANDIDATE;
     }
 
-    public RegistrationRequest(String name, String email, String password) {
+    public RegistrationRequest(String name, String email, String password, Role role) {
         this.name = name;
         this.email = email;
         this.password = password;
+        this.role = role;
     }
 
     public String getName() {
@@ -38,11 +43,20 @@ public class RegistrationRequest {
         this.password = password;
     }
 
+    public Role getRole() {
+        return role;
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
+    }
+
     @Override
     public String toString() {
         return "RegistrationRequest{" +
                 "name='" + name + '\'' +
                 ", email='" + email + '\'' +
+                ", role=" + role +
                 '}';
     }
 }

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/registration/RegistrationService.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/registration/RegistrationService.java
@@ -6,6 +6,8 @@ import com.soen.synapsis.appuser.Role;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import static com.soen.synapsis.utility.Constants.MIN_PASSWORD_LENGTH;
+
 @Service
 public class RegistrationService {
 
@@ -22,14 +24,24 @@ public class RegistrationService {
         boolean isValidEmail = emailValidator.validateEmail(request.getEmail());
 
         if (!isValidEmail) {
-            throw new IllegalStateException("Provided email is not valid");
+            throw new IllegalStateException("The provided email is not valid.");
+        }
+
+        if (request.getPassword().length() < MIN_PASSWORD_LENGTH) {
+            throw new IllegalStateException("The chosen password must be at least " + MIN_PASSWORD_LENGTH + " characters long.");
+        }
+
+        Role requestedRole = request.getRole();
+
+        if (requestedRole != Role.CANDIDATE && requestedRole != Role.COMPANY) {
+            throw new IllegalStateException("The requested role is not valid.");
         }
 
         return appUserService.signUpUser(
                 new AppUser(request.getName(),
                         request.getPassword(),
                         request.getEmail(),
-                        Role.CANDIDATE)
+                        requestedRole)
         );
     }
 }

--- a/synapsis/src/main/java/com/soen/synapsis/utility/Constants.java
+++ b/synapsis/src/main/java/com/soen/synapsis/utility/Constants.java
@@ -1,0 +1,5 @@
+package com.soen.synapsis.utility;
+
+public class Constants {
+    public static final int MIN_PASSWORD_LENGTH = 8;
+}

--- a/synapsis/src/main/java/com/soen/synapsis/utility/ExcludeFromGeneratedTestReport.java
+++ b/synapsis/src/main/java/com/soen/synapsis/utility/ExcludeFromGeneratedTestReport.java
@@ -1,0 +1,11 @@
+package com.soen.synapsis.utility;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface ExcludeFromGeneratedTestReport {
+}

--- a/synapsis/src/main/resources/data.sql
+++ b/synapsis/src/main/resources/data.sql
@@ -1,7 +1,10 @@
 -- Password is 1234
 INSERT INTO app_user (name, password, email, role)
-VALUES ('Joe User', '$2a$12$5E0cSCs0SlULsDfdhsYgxObMbnAbXbIC/gge/uM5U3CjTW2/UFF8.', 'joeuser@mail.com', 'CANDIDATE');
+VALUES ('Joe User', '$2a$12$ShsRhBqy8y9ep/oxB5ury.7cxmcGjt.BQA4i6dhp/RUva/hS7DjHm', 'joeuser@mail.com', 'CANDIDATE');
 
 INSERT INTO app_user (name, password, email, role)
-VALUES ('Joe Admin', '$2a$12$5E0cSCs0SlULsDfdhsYgxObMbnAbXbIC/gge/uM5U3CjTW2/UFF8.', 'joeadmin@mail.com', 'ADMIN');
+VALUES ('Joe Admin', '$2a$12$ShsRhBqy8y9ep/oxB5ury.7cxmcGjt.BQA4i6dhp/RUva/hS7DjHm', 'joeadmin@mail.com', 'ADMIN');
+
+INSERT INTO app_user (name, password, email, role)
+VALUES ('Joe Company', '$2a$12$ShsRhBqy8y9ep/oxB5ury.7cxmcGjt.BQA4i6dhp/RUva/hS7DjHm', 'joecompany@mail.com', 'COMPANY');
 

--- a/synapsis/src/main/resources/templates/pages/register.html
+++ b/synapsis/src/main/resources/templates/pages/register.html
@@ -12,6 +12,17 @@
         <label>Password</label>
         <input type="password" th:field="*{password}" required />
 
+        <fieldset required>
+            <legend>Select which type of account you would like to use:</legend>
+            <div>
+                <input type="radio" name="role" th:field="*{role}" id="candidate-button" value="CANDIDATE" />
+                <label for="candidate-button">Candidate</label>
+
+                <input type="radio" name="role" th:field="*{role}" id="company-button" value="COMPANY" />
+                <label for="company-button">Company</label>
+            </div>
+        </fieldset>
+
         <button type="submit">Register</button>
     </form>
 </div>

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserControllerTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserControllerTest.java
@@ -1,9 +1,6 @@
 package com.soen.synapsis.unit.appuser;
 
-import com.soen.synapsis.appuser.AppUserController;
-import com.soen.synapsis.appuser.AppUserDetailsService;
-import com.soen.synapsis.appuser.AppUserRepository;
-import com.soen.synapsis.appuser.AppUserService;
+import com.soen.synapsis.appuser.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,9 +8,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.ui.Model;
 
+import java.util.Optional;
+
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 class AppUserControllerTest {
 
@@ -34,12 +32,24 @@ class AppUserControllerTest {
     }
 
     @Test
-    void getAppUser() {
+    void getAppUserReturnsUserInfo() {
+        AppUser appUser = new AppUser(1L, "Joe Man", "1234", "joeman@mail.com", Role.CANDIDATE);
+
+        when(appUserService.getAppUser(appUser.getId())).thenReturn(Optional.of(appUser));
+
+        String returnValue = underTest.getAppUser(appUser.getId(), mock(Model.class));
+
+        assertEquals("pages/userpage", returnValue);
+    }
+
+    @Test
+    void getAppUserThatDoesNotExistRedirects() {
         Long id = 1L;
 
-        underTest.getAppUser(id, mock(Model.class));
+        String returnValue = underTest.getAppUser(id, mock(Model.class));
 
         verify(appUserService).getAppUser(id);
+        assertEquals("redirect:/", returnValue);
     }
 
     @Test

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserServiceTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserServiceTest.java
@@ -6,10 +6,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.*;
 
@@ -38,5 +41,30 @@ public class AppUserServiceTest {
         Optional<AppUser> optionalAppUser = underTest.getAppUser(id);
 
         verify(appUserRepository, times(1)).findById(id);
+    }
+
+    @Test
+    void signUpUserWithUniqueEmail() {
+        String email = "joeman@mail.com";
+        AppUser appUser = new AppUser("Joe Man", "1234", email, Role.CANDIDATE);
+
+        when(appUserRepository.findByEmail(email)).thenReturn(null);
+
+        String returnValue = underTest.signUpUser(appUser);
+
+        verify(appUserRepository).save(appUser);
+        assertEquals("pages/home", returnValue);
+    }
+
+    @Test
+    void signUpUserWithExistingEmailThrows() {
+        String email = "joeman@mail.com";
+        AppUser appUser = new AppUser("Joe Man", "1234", email, Role.CANDIDATE);
+
+        when(appUserRepository.findByEmail(email)).thenReturn(appUser);
+
+        Exception exception = assertThrows(IllegalStateException.class,
+                () -> underTest.signUpUser(appUser),
+                "This email is already taken.");
     }
 }

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/registration/RegistrationControllerTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/registration/RegistrationControllerTest.java
@@ -2,6 +2,7 @@ package com.soen.synapsis.unit.appuser.registration;
 
 import com.soen.synapsis.appuser.AppUserController;
 import com.soen.synapsis.appuser.AppUserService;
+import com.soen.synapsis.appuser.Role;
 import com.soen.synapsis.appuser.registration.RegistrationController;
 import com.soen.synapsis.appuser.registration.RegistrationRequest;
 import com.soen.synapsis.appuser.registration.RegistrationService;
@@ -46,7 +47,7 @@ class RegistrationControllerTest {
 
     @Test
     void sendValidRegisterInfo() {
-        RegistrationRequest request = new RegistrationRequest("joe", "joe@maul.com", "1234");
+        RegistrationRequest request = new RegistrationRequest("joe", "joe@maul.com", "1234", Role.CANDIDATE);
 
         underTest.register(request,
                 mock(BindingResult.class),
@@ -58,7 +59,7 @@ class RegistrationControllerTest {
 
     @Test
     void registerWithBindingErrors() {
-        RegistrationRequest request = new RegistrationRequest("joe", "joe@maul.com", "1234");
+        RegistrationRequest request = new RegistrationRequest("joe", "joe@maul.com", "1234", Role.CANDIDATE);
         HttpServletRequest servlet = mock(HttpServletRequest.class);
         Model model = mock(Model.class);
 

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/registration/RegistrationRequestTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/registration/RegistrationRequestTest.java
@@ -1,5 +1,6 @@
 package com.soen.synapsis.unit.appuser.registration;
 
+import com.soen.synapsis.appuser.Role;
 import com.soen.synapsis.appuser.registration.RegistrationRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,13 +14,15 @@ class RegistrationRequestTest {
     private String name;
     private String password;
     private String email;
+    private Role role;
 
     @BeforeEach
     void setUp() {
         name = "joe";
         password = "1234";
         email = "joeunittest@mail.com";
-        underTest = new RegistrationRequest(name, email, password);
+        role = Role.CANDIDATE;
+        underTest = new RegistrationRequest(name, email, password, role);
     }
 
     @Test
@@ -62,6 +65,20 @@ class RegistrationRequestTest {
         underTest.setPassword(newPassword);
 
         assertEquals(newPassword, underTest.getPassword());
+    }
+
+    @Test
+    void getRole() {
+        assertEquals(role, underTest.getRole());
+    }
+
+    @Test
+    void setRole() {
+        Role newRole = Role.ADMIN;
+
+        underTest.setRole(newRole);
+
+        assertEquals(newRole, underTest.getRole());
     }
 
     @Test

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/registration/RegistrationServiceTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/registration/RegistrationServiceTest.java
@@ -13,6 +13,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
+import static com.soen.synapsis.utility.Constants.MIN_PASSWORD_LENGTH;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -39,8 +40,9 @@ class RegistrationServiceTest {
     void registerValidUser() {
         String email = "joe@mail.com";
         String name = "joe";
-        String password = "1234";
-        RegistrationRequest request = new RegistrationRequest(name, email, password);
+        String password = "12345678";
+        Role role = Role.CANDIDATE;
+        RegistrationRequest request = new RegistrationRequest(name, email, password, role);
 
         underTest.register(request);
 
@@ -52,13 +54,38 @@ class RegistrationServiceTest {
     void throwOnInvalidEmail() {
         String email = "joemail.com";
         String name = "joe";
+        String password = "12345678";
+        Role role = Role.CANDIDATE;
+        RegistrationRequest request = new RegistrationRequest(name, email, password, role);
+        String expectedMessage = "The provided email is not valid.";
+
+        assertThrows(IllegalStateException.class,
+                () -> underTest.register(request), expectedMessage);
+    }
+
+    @Test
+    void throwOnInvalidRole() {
+        String email = "joemail.com";
+        String name = "joe";
+        String password = "12345678";
+        Role role = Role.ADMIN;
+        RegistrationRequest request = new RegistrationRequest(name, email, password, role);
+        String expectedMessage = "The requested role is not valid.";
+
+        assertThrows(IllegalStateException.class,
+                () -> underTest.register(request), expectedMessage);
+    }
+
+    @Test
+    void throwOnInvalidPassword() {
+        String email = "joemail.com";
+        String name = "joe";
         String password = "1234";
-        RegistrationRequest request = new RegistrationRequest(name, email, password);
-        String expectedMessage = "Provided email is not valid";
+        Role role = Role.CANDIDATE;
+        RegistrationRequest request = new RegistrationRequest(name, email, password, role);
+        String expectedMessage = "The chosen password must be at least " + MIN_PASSWORD_LENGTH + " characters long.";
 
-        Exception exception = assertThrows(IllegalStateException.class,
-                () -> underTest.register(request));
-
-        assertTrue(exception.getMessage().contentEquals(expectedMessage));
+        assertThrows(IllegalStateException.class,
+                () -> underTest.register(request), expectedMessage);
     }
 }


### PR DESCRIPTION
On the registration page, implement a radio selection to allow users to select if they wish to register as a candidate or as a company. Modify associated backend code and tests.

This PR completes the backend portion of #20 