### PR TITLE
Allow report generation

### DIFF
--- a/synapsis/pom.xml
+++ b/synapsis/pom.xml
@@ -115,6 +115,7 @@
                         <phase>test</phase>
                         <goals>
                             <goal>check</goal>
+                            <goal>report</goal>
                         </goals>
                         <configuration>
                             <rules>


### PR DESCRIPTION
Allow for report generation after running tests, in addition to requiring a minimum coverage check.