### PR TITLE
#21 implement SSO login with Google, including associated tests

### DIFF
--- a/synapsis/pom.xml
+++ b/synapsis/pom.xml
@@ -30,6 +30,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
         </dependency>
         <dependency>

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/AppUser.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/AppUser.java
@@ -11,7 +11,7 @@ public class AppUser {
     @Column(nullable = false)
     private String name;
 
-    @Column(nullable = false)
+    @Column
     private String password;
 
     @Column(unique = true, nullable = false)
@@ -21,21 +21,35 @@ public class AppUser {
     @Enumerated(EnumType.STRING)
     private Role role;
 
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private AuthProvider authProvider;
+
     protected AppUser() {}
 
-    public AppUser(Long id, String name, String password, String email, Role role) {
+    public AppUser(Long id, String name, String password, String email, Role role, AuthProvider authProvider) {
         this.id = id;
         this.name = name;
         this.password = password;
         this.email = email;
         this.role = role;
+        this.authProvider = authProvider;
     }
 
-    public AppUser(String name, String password, String email, Role role) {
+    public AppUser(Long id, String name, String password, String email, Role role) {
+        this(id, name, password, email, role, AuthProvider.LOCAL);
+    }
+
+    public AppUser(String name, String password, String email, Role role, AuthProvider authProvider) {
         this.name = name;
         this.password = password;
         this.email = email;
         this.role = role;
+        this.authProvider = authProvider;
+    }
+
+    public AppUser(String name, String password, String email, Role role) {
+        this(name, password, email, role, AuthProvider.LOCAL);
     }
 
     public Long getId() {
@@ -78,6 +92,14 @@ public class AppUser {
         this.role = role;
     }
 
+    public AuthProvider getAuthProvider() {
+        return authProvider;
+    }
+
+    public void setAuthProvider(AuthProvider authProvider) {
+        this.authProvider = authProvider;
+    }
+
     @Override
     public String toString() {
         return "AppUser{" +
@@ -85,6 +107,7 @@ public class AppUser {
                 ", name='" + name + '\'' +
                 ", email='" + email + '\'' +
                 ", role=" + role +
+                ", authProvider=" + authProvider +
                 '}';
     }
 }

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/AppUserService.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/AppUserService.java
@@ -3,6 +3,7 @@ package com.soen.synapsis.appuser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Component;
+import org.thymeleaf.util.StringUtils;
 
 import java.util.Optional;
 
@@ -20,6 +21,10 @@ public class AppUserService {
 
     public Optional<AppUser> getAppUser(Long id) {
         return appUserRepository.findById(id);
+    }
+
+    public AppUser getAppUser(String email) {
+        return appUserRepository.findByEmail(email);
     }
 
     public String signUpUser(AppUser appUser) {

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/AuthProvider.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/AuthProvider.java
@@ -1,0 +1,6 @@
+package com.soen.synapsis.appuser;
+
+public enum AuthProvider {
+    LOCAL,
+    GOOGLE
+}

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/WebSecurityConfiguration.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/WebSecurityConfiguration.java
@@ -1,7 +1,8 @@
 package com.soen.synapsis.appuser;
 
+import com.soen.synapsis.appuser.oauth.CustomOAuth2UserService;
+//import com.soen.synapsis.appuser.oauth.OAuth2LoginSuccessHandler;
 import com.soen.synapsis.utility.ExcludeFromGeneratedTestReport;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationProvider;
@@ -17,10 +18,12 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private UserDetailsService userDetailsService;
+    private CustomOAuth2UserService oAuth2UserService;
 
-    @Autowired
-    public WebSecurityConfiguration(UserDetailsService userDetailsService) {
+    public WebSecurityConfiguration(UserDetailsService userDetailsService,
+                                    CustomOAuth2UserService oAuth2UserService) {
         this.userDetailsService = userDetailsService;
+        this.oAuth2UserService = oAuth2UserService;
     }
 
     @Bean
@@ -39,10 +42,19 @@ public class WebSecurityConfiguration extends WebSecurityConfigurerAdapter {
                 .antMatchers("/privateuser").hasAuthority(Role.CANDIDATE.toString())
                 .antMatchers("/admin").hasAuthority(Role.ADMIN.toString())
                 .antMatchers("/**").permitAll()
+                .antMatchers("/oauth2/**").permitAll()
                 .anyRequest()
                 .authenticated()
                 .and()
-                .formLogin().loginPage("/login").defaultSuccessUrl("/", true).usernameParameter("email")
+                .formLogin()
+                    .loginPage("/login")
+                    .defaultSuccessUrl("/", true)
+                    .usernameParameter("email")
+                .and()
+                .oauth2Login()
+                    .loginPage("/login")
+                    .userInfoEndpoint().userService(oAuth2UserService)
+                    .and()
                 .and().logout().logoutUrl("/logout").logoutSuccessUrl("/login");
     }
 }

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/WebSecurityConfiguration.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/WebSecurityConfiguration.java
@@ -1,7 +1,6 @@
 package com.soen.synapsis.appuser;
 
 import com.soen.synapsis.appuser.oauth.CustomOAuth2UserService;
-//import com.soen.synapsis.appuser.oauth.OAuth2LoginSuccessHandler;
 import com.soen.synapsis.utility.ExcludeFromGeneratedTestReport;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/oauth/CustomOAuth2User.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/oauth/CustomOAuth2User.java
@@ -1,0 +1,43 @@
+package com.soen.synapsis.appuser.oauth;
+
+import com.soen.synapsis.appuser.AppUser;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.*;
+
+public class CustomOAuth2User implements OAuth2User {
+    private AppUser appUser;
+
+    public CustomOAuth2User(AppUser appUser) {
+        this.appUser = appUser;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        Map<String, Object> attributes = new HashMap<String, Object>();
+        attributes.put("name", appUser.getName());
+        attributes.put("email", appUser.getEmail());
+        attributes.put("role", appUser.getRole().toString());
+
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<GrantedAuthority> authorities = new ArrayList<GrantedAuthority>();
+        authorities.add(new SimpleGrantedAuthority(appUser.getRole().toString()));
+
+        return authorities;
+    }
+
+    @Override
+    public String getName() {
+        return appUser.getName();
+    }
+
+    public String getEmail() {
+        return appUser.getEmail();
+    }
+}

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/oauth/CustomOAuth2UserService.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/oauth/CustomOAuth2UserService.java
@@ -1,0 +1,32 @@
+package com.soen.synapsis.appuser.oauth;
+
+import com.soen.synapsis.appuser.AppUser;
+import com.soen.synapsis.appuser.registration.RegistrationService;
+import com.soen.synapsis.utility.ExcludeFromGeneratedTestReport;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private RegistrationService registrationService;
+
+    @Autowired
+    public CustomOAuth2UserService(RegistrationService registrationService) {
+        this.registrationService = registrationService;
+    }
+
+    @Override
+    @ExcludeFromGeneratedTestReport
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+        AppUser appUser = registrationService.retrieveUserOrRegisterSSOIfNotExists(
+                oAuth2User.getAttribute("name"), oAuth2User.getAttribute("email"));
+
+        return new CustomOAuth2User(appUser);
+    }
+}

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/oauth/CustomOAuth2UserService.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/oauth/CustomOAuth2UserService.java
@@ -24,7 +24,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     @ExcludeFromGeneratedTestReport
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
         OAuth2User oAuth2User = super.loadUser(userRequest);
-        AppUser appUser = registrationService.retrieveUserOrRegisterSSOIfNotExists(
+        AppUser appUser = registrationService.retrieveSSOUserOrRegisterIfNotExists(
                 oAuth2User.getAttribute("name"), oAuth2User.getAttribute("email"));
 
         return new CustomOAuth2User(appUser);

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/registration/RegistrationService.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/registration/RegistrationService.java
@@ -2,7 +2,10 @@ package com.soen.synapsis.appuser.registration;
 
 import com.soen.synapsis.appuser.AppUser;
 import com.soen.synapsis.appuser.AppUserService;
+import com.soen.synapsis.appuser.AuthProvider;
 import com.soen.synapsis.appuser.Role;
+import com.soen.synapsis.appuser.oauth.CustomOAuth2User;
+import com.soen.synapsis.utility.Constants;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -41,7 +44,20 @@ public class RegistrationService {
                 new AppUser(request.getName(),
                         request.getPassword(),
                         request.getEmail(),
-                        requestedRole)
+                        requestedRole,
+                        AuthProvider.LOCAL)
         );
+    }
+
+    public AppUser retrieveUserOrRegisterSSOIfNotExists(String name, String email) {
+        AppUser retrievedUser = appUserService.getAppUser(email);
+        if (retrievedUser != null) {
+            return retrievedUser;
+        }
+
+        AppUser createdUser = new AppUser(name, Constants.SSO_PASSWORD, email, Role.CANDIDATE, AuthProvider.GOOGLE);
+        appUserService.signUpUser(createdUser);
+
+        return createdUser;
     }
 }

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/registration/RegistrationService.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/registration/RegistrationService.java
@@ -49,12 +49,13 @@ public class RegistrationService {
         );
     }
 
-    public AppUser retrieveUserOrRegisterSSOIfNotExists(String name, String email) {
+    public AppUser retrieveSSOUserOrRegisterIfNotExists(String name, String email) {
         AppUser retrievedUser = appUserService.getAppUser(email);
         if (retrievedUser != null) {
             return retrievedUser;
         }
 
+        //User does not exist. Create the account.
         AppUser createdUser = new AppUser(name, Constants.SSO_PASSWORD, email, Role.CANDIDATE, AuthProvider.GOOGLE);
         appUserService.signUpUser(createdUser);
 

--- a/synapsis/src/main/java/com/soen/synapsis/utility/Constants.java
+++ b/synapsis/src/main/java/com/soen/synapsis/utility/Constants.java
@@ -2,4 +2,5 @@ package com.soen.synapsis.utility;
 
 public class Constants {
     public static final int MIN_PASSWORD_LENGTH = 8;
+    public static final String SSO_PASSWORD = "";
 }

--- a/synapsis/src/main/resources/application.properties
+++ b/synapsis/src/main/resources/application.properties
@@ -9,3 +9,6 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.format_sql=true
 spring.sql.init.mode=always
 spring.jpa.defer-datasource-initialization=true
+spring.security.oauth2.client.registration.google.client-id=337739041995-a0nn8plaogqpfp9s3d3ebevur0fksfak.apps.googleusercontent.com
+spring.security.oauth2.client.registration.google.client-secret=mysecret
+spring.security.oauth2.client.registration.google.scope=email,profile

--- a/synapsis/src/main/resources/data.sql
+++ b/synapsis/src/main/resources/data.sql
@@ -1,10 +1,10 @@
--- Password is 1234
-INSERT INTO app_user (name, password, email, role)
-VALUES ('Joe User', '$2a$12$ShsRhBqy8y9ep/oxB5ury.7cxmcGjt.BQA4i6dhp/RUva/hS7DjHm', 'joeuser@mail.com', 'CANDIDATE');
+-- Password is 12345678
+INSERT INTO app_user (name, password, email, role, auth_provider)
+VALUES ('Joe User', '$2a$12$ShsRhBqy8y9ep/oxB5ury.7cxmcGjt.BQA4i6dhp/RUva/hS7DjHm', 'joeuser@mail.com', 'CANDIDATE', 'LOCAL');
 
-INSERT INTO app_user (name, password, email, role)
-VALUES ('Joe Admin', '$2a$12$ShsRhBqy8y9ep/oxB5ury.7cxmcGjt.BQA4i6dhp/RUva/hS7DjHm', 'joeadmin@mail.com', 'ADMIN');
+INSERT INTO app_user (name, password, email, role, auth_provider)
+VALUES ('Joe Admin', '$2a$12$ShsRhBqy8y9ep/oxB5ury.7cxmcGjt.BQA4i6dhp/RUva/hS7DjHm', 'joeadmin@mail.com', 'ADMIN', 'LOCAL');
 
-INSERT INTO app_user (name, password, email, role)
-VALUES ('Joe Company', '$2a$12$ShsRhBqy8y9ep/oxB5ury.7cxmcGjt.BQA4i6dhp/RUva/hS7DjHm', 'joecompany@mail.com', 'COMPANY');
+INSERT INTO app_user (name, password, email, role, auth_provider)
+VALUES ('Joe Company', '$2a$12$ShsRhBqy8y9ep/oxB5ury.7cxmcGjt.BQA4i6dhp/RUva/hS7DjHm', 'joecompany@mail.com', 'COMPANY', 'LOCAL');
 

--- a/synapsis/src/main/resources/data.sql
+++ b/synapsis/src/main/resources/data.sql
@@ -8,3 +8,5 @@ VALUES ('Joe Admin', '$2a$12$ShsRhBqy8y9ep/oxB5ury.7cxmcGjt.BQA4i6dhp/RUva/hS7Dj
 INSERT INTO app_user (name, password, email, role, auth_provider)
 VALUES ('Joe Company', '$2a$12$ShsRhBqy8y9ep/oxB5ury.7cxmcGjt.BQA4i6dhp/RUva/hS7DjHm', 'joecompany@mail.com', 'COMPANY', 'LOCAL');
 
+INSERT INTO app_user (name, password, email, role, auth_provider)
+VALUES ('Joe Google', '$2a$12$ShsRhBqy8y9ep/oxB5ury.7cxmcGjt.BQA4i6dhp/RUva/hS7DjHm', 'joegoogle@mail.com', 'CANDIDATE', 'GOOGLE');

--- a/synapsis/src/main/resources/templates/pages/login.html
+++ b/synapsis/src/main/resources/templates/pages/login.html
@@ -58,15 +58,7 @@
 
                 <hr class="mt-3 text-black">
 
-                <a class="mt-5 h-14 bg-facebook-blue rounded-md drop-shadow-md">
-                    <div class="mt-4">
-                        <img class="ml-3 mb-1 w-6 h-6 inline" src="/assets/facebook-logo.png">
-                        <div class="ml-2 mr-3 text-center text-white text-xl font-serif font-normal inline">Sign In with
-                            Facebook
-                        </div>
-                    </div>
-                </a>
-                <a class="mt-5 h-14 bg-white rounded-md drop-shadow-md">
+                <a th:href="@{/oauth2/authorization/google}" class="mt-5 h-14 bg-white rounded-md drop-shadow-md">
                     <div class="mt-4">
                         <img class="ml-3 mb-1 w-6 h-6 inline" src="/assets/google-logo.png">
                         <div class="ml-2 mr-3 text-center text-black text-xl font-serif font-normal inline">Sign In with
@@ -74,14 +66,7 @@
                         </div>
                     </div>
                 </a>
-                <a class="mt-5 h-14 bg-true-black rounded-md drop-shadow-md">
-                    <div class="mt-4">
-                        <img class="ml-4 mb-2 w-5 h-6 inline" src="/assets/apple-logo.png">
-                        <div class="ml-2 mr-3 text-center text-white text-xl font-serif font-normal inline">Sign In with
-                            Apple
-                        </div>
-                    </div>
-                </a>
+
                 <div class="mt-5 mb-4 text-black font-serif font-normal text-base ">
                     Don't have an account? <a class="text-primary">Click here</a>
                 </div>

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserDetailsServiceTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserDetailsServiceTest.java
@@ -1,17 +1,17 @@
 package com.soen.synapsis.unit.appuser;
 
-import com.soen.synapsis.appuser.AppUserDetailsService;
-import com.soen.synapsis.appuser.AppUserRepository;
+import com.soen.synapsis.appuser.*;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 class AppUserDetailsServiceTest {
 
@@ -34,13 +34,16 @@ class AppUserDetailsServiceTest {
     @Test
     void loadUserByUsername() {
         String email = "joeusertest@mail.com";
+        when(appUserRepository.findByEmail(email)).thenReturn(new AppUser("joe", "12345678", "joe@mail.com", Role.CANDIDATE));
+        UserDetails returnedUserDetails = null;
 
         try {
-            underTest.loadUserByUsername(email);
+            returnedUserDetails = underTest.loadUserByUsername(email);
         }
         catch (Exception e) {}
 
         verify(appUserRepository).findByEmail(email);
+        assertNotNull(returnedUserDetails);
     }
 
     @Test

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserServiceTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserServiceTest.java
@@ -44,6 +44,15 @@ public class AppUserServiceTest {
     }
 
     @Test
+    void getAppUserByEmailReturnsUser() {
+        String email = "joe@mail.com";
+
+        AppUser appUser = underTest.getAppUser(email);
+
+        verify(appUserRepository, times(1)).findByEmail(email);
+    }
+
+    @Test
     void signUpUserWithUniqueEmail() {
         String email = "joeman@mail.com";
         AppUser appUser = new AppUser("Joe Man", "1234", email, Role.CANDIDATE);

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserTest.java
@@ -1,6 +1,7 @@
 package com.soen.synapsis.unit.appuser;
 
 import com.soen.synapsis.appuser.AppUser;
+import com.soen.synapsis.appuser.AuthProvider;
 import com.soen.synapsis.appuser.Role;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,6 +17,7 @@ class AppUserTest {
     private String password;
     private String email;
     private Role role;
+    private AuthProvider authProvider;
 
     @BeforeEach
     void setUp() {
@@ -24,7 +26,8 @@ class AppUserTest {
         password = "1234";
         email = "joeunittest@mail.com";
         role = Role.CANDIDATE;
-        underTest = new AppUser(id, name, password, email, role);
+        authProvider = AuthProvider.LOCAL;
+        underTest = new AppUser(id, name, password, email, role, authProvider);
     }
 
     @Test
@@ -95,6 +98,20 @@ class AppUserTest {
         underTest.setRole(newRole);
 
         assertEquals(newRole, underTest.getRole());
+    }
+
+    @Test
+    void getAuthProvider() {
+        assertEquals(authProvider, underTest.getAuthProvider());
+    }
+
+    @Test
+    void setAuthProvider() {
+        AuthProvider newAuthProvider = AuthProvider.GOOGLE;
+
+        underTest.setAuthProvider(newAuthProvider);
+
+        assertEquals(newAuthProvider, underTest.getAuthProvider());
     }
 
     @Test

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/WebSecurityConfigurationTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/WebSecurityConfigurationTest.java
@@ -3,6 +3,7 @@ package com.soen.synapsis.unit.appuser;
 import com.soen.synapsis.appuser.AppUserDetailsService;
 import com.soen.synapsis.appuser.AppUserRepository;
 import com.soen.synapsis.appuser.WebSecurityConfiguration;
+import com.soen.synapsis.appuser.oauth.CustomOAuth2UserService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -19,11 +20,13 @@ class WebSecurityConfigurationTest {
     private AutoCloseable autoCloseable;
     @Mock
     private AppUserDetailsService appUserDetailsService;
+    @Mock
+    private CustomOAuth2UserService customOAuth2UserService;
 
     @BeforeEach
     void setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this);
-        underTest = new WebSecurityConfiguration(appUserDetailsService);
+        underTest = new WebSecurityConfiguration(appUserDetailsService, customOAuth2UserService);
     }
 
     @AfterEach

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/oauth/CustomOAuth2UserTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/oauth/CustomOAuth2UserTest.java
@@ -1,0 +1,60 @@
+package com.soen.synapsis.unit.appuser.oauth;
+
+import com.soen.synapsis.appuser.AppUser;
+import com.soen.synapsis.appuser.Role;
+import com.soen.synapsis.appuser.oauth.CustomOAuth2User;
+import com.soen.synapsis.utility.Constants;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CustomOAuth2UserTest {
+
+    private CustomOAuth2User underTest;
+    private String name;
+    private String email;
+    private Role role;
+
+    @BeforeEach
+    void setUp() {
+        name = "Joe Smith";
+        email = "joe@mail.com";
+        role = Role.CANDIDATE;
+        underTest = new CustomOAuth2User(new AppUser(name, Constants.SSO_PASSWORD, email, role));
+    }
+
+    @Test
+    void getAttributes() {
+        Map<String, Object> attributes = underTest.getAttributes();
+
+        assertEquals(name, attributes.get("name"));
+        assertEquals(email, attributes.get("email"));
+        assertEquals(role.toString(), attributes.get("role"));
+    }
+
+    @Test
+    void getAuthorities() {
+        List<GrantedAuthority> authorities = (List<GrantedAuthority>) underTest.getAuthorities();
+
+        assertEquals(role.toString(), authorities.get(0).getAuthority());
+    }
+
+    @Test
+    void getName() {
+        String retrievedName = underTest.getName();
+
+        assertEquals(name, retrievedName);
+    }
+
+    @Test
+    void getEmail() {
+        String retrievedEmail = underTest.getEmail();
+
+        assertEquals(email, retrievedEmail);
+    }
+}

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/registration/RegistrationServiceTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/registration/RegistrationServiceTest.java
@@ -95,7 +95,7 @@ class RegistrationServiceTest {
         String email = "joe@mail.com";
         when(appUserService.getAppUser(email)).thenReturn(new AppUser("joe", "1234", email, Role.CANDIDATE));
 
-        AppUser retrievedUser = underTest.retrieveUserOrRegisterSSOIfNotExists("joe", email);
+        AppUser retrievedUser = underTest.retrieveSSOUserOrRegisterIfNotExists("joe", email);
 
         assertNotNull(retrievedUser);
     }
@@ -105,7 +105,7 @@ class RegistrationServiceTest {
         String name = "joe";
         String email = "joe@mail.com";
 
-        AppUser createdUser = underTest.retrieveUserOrRegisterSSOIfNotExists(name, email);
+        AppUser createdUser = underTest.retrieveSSOUserOrRegisterIfNotExists(name, email);
 
         assertEquals(name, createdUser.getName());
         assertEquals(Constants.SSO_PASSWORD, createdUser.getPassword());

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/registration/RegistrationServiceTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/registration/RegistrationServiceTest.java
@@ -2,10 +2,12 @@ package com.soen.synapsis.unit.appuser.registration;
 
 import com.soen.synapsis.appuser.AppUser;
 import com.soen.synapsis.appuser.AppUserService;
+import com.soen.synapsis.appuser.AuthProvider;
 import com.soen.synapsis.appuser.Role;
 import com.soen.synapsis.appuser.registration.EmailValidator;
 import com.soen.synapsis.appuser.registration.RegistrationRequest;
 import com.soen.synapsis.appuser.registration.RegistrationService;
+import com.soen.synapsis.utility.Constants;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,8 +17,7 @@ import org.mockito.MockitoAnnotations;
 
 import static com.soen.synapsis.utility.Constants.MIN_PASSWORD_LENGTH;
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 class RegistrationServiceTest {
 
@@ -87,5 +88,29 @@ class RegistrationServiceTest {
 
         assertThrows(IllegalStateException.class,
                 () -> underTest.register(request), expectedMessage);
+    }
+
+    @Test
+    void ssoRetrievalReturnsFoundUser() {
+        String email = "joe@mail.com";
+        when(appUserService.getAppUser(email)).thenReturn(new AppUser("joe", "1234", email, Role.CANDIDATE));
+
+        AppUser retrievedUser = underTest.retrieveUserOrRegisterSSOIfNotExists("joe", email);
+
+        assertNotNull(retrievedUser);
+    }
+
+    @Test
+    void ssoRegisterSuccessfullyInsertsNewUser() {
+        String name = "joe";
+        String email = "joe@mail.com";
+
+        AppUser createdUser = underTest.retrieveUserOrRegisterSSOIfNotExists(name, email);
+
+        assertEquals(name, createdUser.getName());
+        assertEquals(Constants.SSO_PASSWORD, createdUser.getPassword());
+        assertEquals(email, createdUser.getEmail());
+        assertEquals(Role.CANDIDATE, createdUser.getRole());
+        assertEquals(AuthProvider.GOOGLE, createdUser.getAuthProvider());
     }
 }

--- a/synapsis/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/synapsis/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
Allow user to sign in from the login page using their Google account. The user maintains access to their authorities and is added to the database as other users, marked as having a GOOGLE AuthProvider. The associated tests are written.

This PR closes #21 