### PR TITLE
#82 Generate javadocs on merge to main

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -1,0 +1,36 @@
+name: Generate Documentation
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Setup Maven
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: 3.8.7
+
+      - name: Run documentation generation
+        run: mvn javadoc:javadoc --file synapsis/pom.xml
+
+      - name: Upload documentation artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: apidocs
+          path: synapsis/target/site/apidocs

--- a/synapsis/pom.xml
+++ b/synapsis/pom.xml
@@ -152,6 +152,14 @@
                 <artifactId>maven-pmd-plugin</artifactId>
                 <version>3.7</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.4.1</version>
+                <configuration>
+                    <show>public</show>
+                </configuration>
+            </plugin>
         </plugins>
     </reporting>
 


### PR DESCRIPTION
On merging to main, Javadocs will be generated by Github Actions and will be saved as an artifact to be viewable.

This PR closes #82 