### PR TITLE
#102 recognize Google users when verifying authentication

### DIFF
--- a/synapsis/src/main/java/com/soen/synapsis/appuser/AppUser.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/AppUser.java
@@ -114,15 +114,6 @@ public class AppUser {
         this.role = role;
     }
 
-    public static boolean isUserAuthenticated() {
-        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-
-        if (auth == null || auth instanceof AnonymousAuthenticationToken)
-            return false;
-
-        return true;
-    }
-
     public AuthProvider getAuthProvider() {
         return authProvider;
     }
@@ -170,16 +161,6 @@ public class AppUser {
             throw new IllegalStateException("You must be a recruiter to be part of a company.");
         }
         this.company = company;
-    }
-
-    public static AppUser getAuthenticatedUser() {
-        if (!isUserAuthenticated()) {
-            throw new IllegalStateException("User not registered");
-        }
-
-        AppUserDetails appUserDetails = (AppUserDetails) SecurityContextHolder.getContext().getAuthentication()
-                .getPrincipal();
-        return appUserDetails.getAppUser();
     }
 
     public AppUserProfile getAppUserProfile() {

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/AppUserAuth.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/AppUserAuth.java
@@ -1,0 +1,5 @@
+package com.soen.synapsis.appuser;
+
+public interface AppUserAuth {
+    AppUser getAppUser();
+}

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/AppUserController.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/AppUserController.java
@@ -17,27 +17,35 @@ public class AppUserController {
 
     private final AppUserService appUserService;
     private final ConnectionService connectionService;
+    private final AuthService authService;
 
     @Autowired
     public AppUserController(AppUserService appUserService, ConnectionService connectionService) {
         this.appUserService = appUserService;
         this.connectionService = connectionService;
+        this.authService = new AuthService();
+    }
+
+    public AppUserController(AppUserService appUserService, ConnectionService connectionService, AuthService authService) {
+        this.appUserService = appUserService;
+        this.connectionService = connectionService;
+        this.authService = authService;
     }
 
     @GetMapping("/user")
-    public String redirectToAuthenticatedUserProfile(@AuthenticationPrincipal AppUserDetails user) {
-        if (!AppUser.isUserAuthenticated()) {
+    public String redirectToAuthenticatedUserProfile() {
+        if (!authService.isUserAuthenticated()) {
             return "redirect:/";
         }
 
-        String userProfileURL = "redirect:/user/" + user.getID();
+        String userProfileURL = "redirect:/user/" + authService.getAuthenticatedUser().getId();
 
         return userProfileURL;
     }
 
     @GetMapping("/user/{uid}")
-    public String getAppUser(@AuthenticationPrincipal AppUserDetails user, @PathVariable Long uid, Model model) {
-        if (!AppUser.isUserAuthenticated()) {
+    public String getAppUser(@PathVariable Long uid, Model model) {
+        if (!authService.isUserAuthenticated()) {
             return "redirect:/";
         }
 
@@ -47,7 +55,7 @@ public class AppUserController {
             return "redirect:/";
 
         AppUser appUser = optionalAppUser.get();
-        boolean isConnectedWith = connectionService.isConnectedWith(user.getID(), uid);
+        boolean isConnectedWith = connectionService.isConnectedWith(authService.getAuthenticatedUser().getId(), uid);
 
         model.addAttribute("id", appUser.getId());
         model.addAttribute("name", appUser.getName());
@@ -56,6 +64,9 @@ public class AppUserController {
 
         if (appUser.getRole() == Role.COMPANY) {
             CompanyProfile companyProfile = appUser.getCompanyProfile();
+            if (companyProfile == null)
+                companyProfile = new CompanyProfile();
+
             model.addAttribute("website", companyProfile.getWebsite());
             model.addAttribute("industry", companyProfile.getIndustry());
             model.addAttribute("companySize", companyProfile.getCompanySize());
@@ -65,6 +76,9 @@ public class AppUserController {
         }
 
         AppUserProfile profile = appUser.getAppUserProfile();
+        if (profile == null)
+            profile = new AppUserProfile();
+
         model.addAttribute("education", profile.getEducation());
         model.addAttribute("skill", profile.getSkill());
         model.addAttribute("work", profile.getWork());
@@ -80,12 +94,12 @@ public class AppUserController {
     }
 
     @GetMapping("/search")
-    public String getUsersLikeName(@AuthenticationPrincipal AppUserDetails user, @RequestParam String name, Model model) {
-        if (!AppUser.isUserAuthenticated()) {
+    public String getUsersLikeName(@RequestParam String name, Model model) {
+        if (!authService.isUserAuthenticated()) {
             return "redirect:/";
         }
 
-        List<AppUser> users = appUserService.getUsersLikeName(name, user.getId());
+        List<AppUser> users = appUserService.getUsersLikeName(name, authService.getAuthenticatedUser().getId());
         model.addAttribute("users", users);
         return "pages/usersearchpage";
     }
@@ -104,12 +118,12 @@ public class AppUserController {
 
     @PutMapping("/company/markCandidateToRecruiter")
     @ResponseBody
-    public String markCandidateToRecruiter(AppUser appUser, @AuthenticationPrincipal AppUser companyUser) {
-        if (companyUser.getRole() != Role.COMPANY) {
+    public String markCandidateToRecruiter(AppUser appUser) {
+        if (!authService.doesUserHaveRole(Role.COMPANY)) {
             return "You must be a company to mark candidates as recruiters.";
         }
         try {
-            appUserService.markCandidateToRecruiter(appUser, companyUser);
+            appUserService.markCandidateToRecruiter(appUser, authService.getAuthenticatedUser());
         } catch (IllegalStateException e) {
             return e.getMessage();
         }
@@ -118,12 +132,12 @@ public class AppUserController {
 
     @PutMapping("/company/unmarkRecruiterToCandidate")
     @ResponseBody
-    public String unmarkRecruiterToCandidate(AppUser appUser, @AuthenticationPrincipal AppUser companyUser) {
-        if (companyUser.getRole() != Role.COMPANY) {
+    public String unmarkRecruiterToCandidate(AppUser appUser) {
+        if (!authService.doesUserHaveRole(Role.COMPANY)) {
             return "You must be a company to unmark recruiters as candidates.";
         }
         try {
-            appUserService.unmarkRecruiterToCandidate(appUser, companyUser);
+            appUserService.unmarkRecruiterToCandidate(appUser, authService.getAuthenticatedUser());
         } catch (IllegalStateException e) {
             return e.getMessage();
         }
@@ -134,5 +148,4 @@ public class AppUserController {
     public String getUpdateUserProfile() {
         return "pages/updateuserpage";
     }
-
 }

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/AppUserDetails.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/AppUserDetails.java
@@ -7,7 +7,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import java.util.Collection;
 import java.util.Collections;
 
-public class AppUserDetails implements UserDetails {
+public class AppUserDetails implements UserDetails, AppUserAuth {
 
     private AppUser appUser;
 

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/AuthService.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/AuthService.java
@@ -1,0 +1,51 @@
+package com.soen.synapsis.appuser;
+
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthService {
+    public boolean isUserAuthenticated() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth == null || auth instanceof AnonymousAuthenticationToken)
+            return false;
+
+        return true;
+    }
+
+    public AppUser getAuthenticatedUser() {
+        if (!this.isUserAuthenticated()) {
+            throw new IllegalStateException("User not registered");
+        }
+
+        AppUserAuth appUserAuth = (AppUserAuth) SecurityContextHolder.getContext().getAuthentication()
+                .getPrincipal();
+        return appUserAuth.getAppUser();
+    }
+
+    public boolean doesUserHaveRole(Role role) {
+        // User is not logged in, return false
+        if (!this.isUserAuthenticated()) {
+            return false;
+        }
+
+        // User logged in with correct role, return true
+        Role authedUserRole = this.getAuthenticatedUser().getRole();
+        if (authedUserRole == role) {
+            return true;
+        }
+
+        // User logged in with incorrect role, return false
+        return false;
+    }
+
+    public boolean doesUserHaveRole(Role role1, Role role2) {
+        if (this.doesUserHaveRole(role1) || this.doesUserHaveRole(role2))
+            return true;
+
+        return false;
+    }
+}

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/connection/ConnectionService.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/connection/ConnectionService.java
@@ -20,9 +20,9 @@ public class ConnectionService {
         this.appUserRepository = appUserRepository;
     }
 
-    public List<AppUser> getConnections(AppUserDetails appUser) {
-        List<Connection> connectionsRequesters = connectionRepository.findAcceptedConnectionsByRequesterID(appUser.getID());
-        List<Connection> connectionsReceivers = connectionRepository.findAcceptedConnectionsByReceiverID(appUser.getID());
+    public List<AppUser> getConnections(AppUser appUser) {
+        List<Connection> connectionsRequesters = connectionRepository.findAcceptedConnectionsByRequesterID(appUser.getId());
+        List<Connection> connectionsReceivers = connectionRepository.findAcceptedConnectionsByReceiverID(appUser.getId());
 
         List<Long> allConnectionIDs = new ArrayList<>();
 
@@ -49,12 +49,12 @@ public class ConnectionService {
         return allConnections;
     }
 
-    public List<AppUser> getPendingConnectionRequest(AppUserDetails user) {
-        return connectionRepository.findPendingConnectionsByReceiverID(user.getID());
+    public List<AppUser> getPendingConnectionRequest(AppUser user) {
+        return connectionRepository.findPendingConnectionsByReceiverID(user.getId());
     }
 
-    public String rejectConnection(AppUserDetails user, Long id) {
-        ConnectionKey connectionKey = new ConnectionKey(id, user.getID());
+    public String rejectConnection(AppUser user, Long id) {
+        ConnectionKey connectionKey = new ConnectionKey(id, user.getId());
         Optional<Connection> retrievedConnection = connectionRepository.findById(connectionKey);
 
         if (!retrievedConnection.isPresent()) {
@@ -72,8 +72,8 @@ public class ConnectionService {
         return "redirect:/network";
     }
 
-    public String acceptConnection(AppUserDetails user, Long id) {
-        ConnectionKey connectionKey = new ConnectionKey(id, user.getID());
+    public String acceptConnection(AppUser user, Long id) {
+        ConnectionKey connectionKey = new ConnectionKey(id, user.getId());
         Optional<Connection> retrievedConnection = connectionRepository.findById(connectionKey);
 
         if (!retrievedConnection.isPresent()) {

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/job/JobController.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/job/JobController.java
@@ -3,6 +3,7 @@ package com.soen.synapsis.appuser.job;
 import com.soen.synapsis.appuser.AppUser;
 import com.soen.synapsis.appuser.AppUserDetails;
 import com.soen.synapsis.appuser.AppUserService;
+import com.soen.synapsis.appuser.AuthService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -19,13 +20,19 @@ import java.util.Optional;
 public class JobController {
 
     private final JobService jobService;
-    private final AppUserService appUserService;
+    private final AuthService authService;
 
     @Autowired
-    public JobController(JobService jobService, AppUserService appUserService) {
+    public JobController(JobService jobService) {
         this.jobService = jobService;
-        this.appUserService = appUserService;
+        this.authService = new AuthService();
     }
+
+    public JobController(JobService jobService, AuthService authService) {
+        this.jobService = jobService;
+        this.authService = authService;
+    }
+
 
     @GetMapping("/job/{jid}")
     public String getJob(@PathVariable Long jid, Model model) {
@@ -55,13 +62,13 @@ public class JobController {
     }
 
     @PostMapping("/createjob")
-    public String createJob(JobRequest request, BindingResult bindingResult, Model model, @AuthenticationPrincipal AppUserDetails creatorDetails) {
+    public String createJob(JobRequest request, BindingResult bindingResult, Model model) {
         try {
             if (bindingResult.hasErrors()) {
                 throw new Exception();
             }
 
-            AppUser creator = appUserService.getAppUser(creatorDetails.getUsername());
+            AppUser creator = authService.getAuthenticatedUser();
             request.setCreator(creator);
             String response = jobService.createJob(request);
 

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/oauth/CustomOAuth2User.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/oauth/CustomOAuth2User.java
@@ -1,13 +1,14 @@
 package com.soen.synapsis.appuser.oauth;
 
 import com.soen.synapsis.appuser.AppUser;
+import com.soen.synapsis.appuser.AppUserAuth;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.*;
 
-public class CustomOAuth2User implements OAuth2User {
+public class CustomOAuth2User implements OAuth2User, AppUserAuth {
     private AppUser appUser;
 
     public CustomOAuth2User(AppUser appUser) {
@@ -39,5 +40,9 @@ public class CustomOAuth2User implements OAuth2User {
 
     public String getEmail() {
         return appUser.getEmail();
+    }
+
+    public AppUser getAppUser() {
+        return appUser;
     }
 }

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/profile/appuserprofile/updateprofile/UpdateAppUserProfileController.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/profile/appuserprofile/updateprofile/UpdateAppUserProfileController.java
@@ -1,6 +1,7 @@
 package com.soen.synapsis.appuser.profile.appuserprofile.updateprofile;
 
 import com.soen.synapsis.appuser.AppUser;
+import com.soen.synapsis.appuser.AuthService;
 import com.soen.synapsis.appuser.Role;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -12,15 +13,22 @@ import org.springframework.web.bind.annotation.PostMapping;
 @Controller
 public class UpdateAppUserProfileController {
     private UpdateAppUserProfileService updateAppUserProfileService;
+    private AuthService authService;
 
     @Autowired
     public UpdateAppUserProfileController(UpdateAppUserProfileService updateAppUserProfileService) {
         this.updateAppUserProfileService = updateAppUserProfileService;
+        this.authService = new AuthService();
+    }
+
+    public UpdateAppUserProfileController(UpdateAppUserProfileService updateAppUserProfileService, AuthService authService) {
+        this.updateAppUserProfileService = updateAppUserProfileService;
+        this.authService = authService;
     }
 
     @GetMapping("/user/update")
     public String updateAppUserProfile(Model model) {
-        if (!AppUser.isUserAuthenticated() || AppUser.getAuthenticatedUser().getRole() != Role.CANDIDATE) {
+        if (!authService.doesUserHaveRole(Role.CANDIDATE, Role.RECRUITER)) {
             return "redirect:/";
         }
 
@@ -30,7 +38,7 @@ public class UpdateAppUserProfileController {
 
     @PostMapping("/user/update")
     public String updateAppUserProfile(UpdateAppUserProfileRequest request, BindingResult bindingResult, Model model) {
-        if (!AppUser.isUserAuthenticated() || AppUser.getAuthenticatedUser().getRole() != Role.CANDIDATE) {
+        if (!authService.doesUserHaveRole(Role.CANDIDATE, Role.RECRUITER)) {
             return "redirect:/";
         }
         try {
@@ -38,7 +46,7 @@ public class UpdateAppUserProfileController {
                 throw new Exception();
             }
 
-            return updateAppUserProfileService.updateProfile(request, AppUser.getAuthenticatedUser());
+            return updateAppUserProfileService.updateProfile(request, authService.getAuthenticatedUser());
         } catch (Exception e) {
             model.addAttribute("error", "There was an error updating. " + e.getMessage());
             return updateAppUserProfile(model);

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/profile/companyprofile/updateprofile/UpdateCompanyProfileController.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/profile/companyprofile/updateprofile/UpdateCompanyProfileController.java
@@ -1,6 +1,7 @@
 package com.soen.synapsis.appuser.profile.companyprofile.updateprofile;
 
 import com.soen.synapsis.appuser.AppUser;
+import com.soen.synapsis.appuser.AuthService;
 import com.soen.synapsis.appuser.Role;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -13,15 +14,17 @@ import org.springframework.web.bind.annotation.PostMapping;
 public class UpdateCompanyProfileController {
 
     private UpdateCompanyProfileService updateCompanyProfileService;
+    private AuthService authService;
 
     @Autowired
     public UpdateCompanyProfileController(UpdateCompanyProfileService updateCompanyProfileService) {
         this.updateCompanyProfileService = updateCompanyProfileService;
+        this.authService = new AuthService();
     }
 
     @GetMapping("/company/update")
     public String updateAppUserProfile(Model model) {
-        if (!AppUser.isUserAuthenticated() || AppUser.getAuthenticatedUser().getRole() != Role.COMPANY) {
+        if (!authService.doesUserHaveRole(Role.COMPANY)) {
             return "redirect:/";
         }
 
@@ -31,7 +34,7 @@ public class UpdateCompanyProfileController {
 
     @PostMapping("/company/update")
     public String updateAppUserProfile(UpdateCompanyProfileRequest request, BindingResult bindingResult, Model model) {
-        if (!AppUser.isUserAuthenticated() || AppUser.getAuthenticatedUser().getRole() != Role.COMPANY) {
+        if (!authService.doesUserHaveRole(Role.COMPANY)) {
             return "redirect:/";
         }
         try {
@@ -39,7 +42,7 @@ public class UpdateCompanyProfileController {
                 throw new Exception();
             }
 
-            return updateCompanyProfileService.updateProfile(request, AppUser.getAuthenticatedUser());
+            return updateCompanyProfileService.updateProfile(request, authService.getAuthenticatedUser());
         } catch (Exception e) {
             model.addAttribute("error", "There was an error updating. " + e.getMessage());
             return updateAppUserProfile(model);

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/registration/RegistrationController.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/registration/RegistrationController.java
@@ -1,6 +1,7 @@
 package com.soen.synapsis.appuser.registration;
 
 import com.soen.synapsis.appuser.AppUser;
+import com.soen.synapsis.appuser.AuthService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -14,15 +15,17 @@ import javax.servlet.http.HttpServletRequest;
 public class RegistrationController {
 
     private RegistrationService registrationService;
+    private AuthService authService;
 
     @Autowired
     public RegistrationController(RegistrationService registrationService) {
         this.registrationService = registrationService;
+        this.authService = new AuthService();
     }
 
     @GetMapping("/register")
     public String register(Model model) {
-        if (AppUser.isUserAuthenticated())
+        if (authService.isUserAuthenticated())
             return "redirect:/";
 
         model.addAttribute("registrationRequest", new RegistrationRequest());
@@ -35,7 +38,7 @@ public class RegistrationController {
                            BindingResult bindingResult,
                            HttpServletRequest servlet,
                            Model model) {
-        if (AppUser.isUserAuthenticated())
+        if (authService.isUserAuthenticated())
             return "redirect:/";
 
         try {
@@ -56,7 +59,7 @@ public class RegistrationController {
 
     @GetMapping(value = "/admincreation")
     public String registerAdmin(Model model) {
-        if (AppUser.isUserAuthenticated()) {
+        if (authService.isUserAuthenticated()) {
             model.addAttribute("registrationRequest", new RegistrationRequest());
 
             return "pages/adminCreationPage";
@@ -75,7 +78,7 @@ public class RegistrationController {
                 throw new Exception();
             }
 
-            if (AppUser.isUserAuthenticated()) {
+            if (authService.isUserAuthenticated()) {
                 String response = registrationService.registerAdmin(request);
                 return response;
             }
@@ -116,7 +119,7 @@ public class RegistrationController {
 
     @GetMapping("/login")
     public String viewLoginPage() {
-        if (AppUser.isUserAuthenticated())
+        if (authService.isUserAuthenticated())
             return "redirect:/";
 
         return "pages/login";

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserControllerTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserControllerTest.java
@@ -23,13 +23,15 @@ class AppUserControllerTest {
     private AppUserService appUserService;
     @Mock
     private ConnectionService connectionService;
+    @Mock
+    private AuthService authService;
     private AutoCloseable autoCloseable;
     private AppUserController underTest;
 
     @BeforeEach
     void setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this);
-        underTest = new AppUserController(appUserService, connectionService);
+        underTest = new AppUserController(appUserService, connectionService, authService);
     }
 
     @AfterEach
@@ -40,14 +42,13 @@ class AppUserControllerTest {
 
     @Test
     void getAppUserReturnsUserInfo() {
-        AppUser appUser = mock(AppUser.class);
-        AppUserDetails appUserDetails = new AppUserDetails(appUser);
-        SecurityUtilities.authenticateAnonymousUser();
+        AppUser appUser = new AppUser(1L, "Joe Man", "1234", "joeman@mail.com", Role.CANDIDATE);
+        when(authService.getAuthenticatedUser()).thenReturn(appUser);
+        when(authService.isUserAuthenticated()).thenReturn(true);
 
         when(appUserService.getAppUser(any(Long.class))).thenReturn(Optional.of(appUser));
-        when(appUser.getAppUserProfile()).thenReturn(new AppUserProfile());
 
-        String returnValue = underTest.getAppUser(appUserDetails, 1L, mock(Model.class));
+        String returnValue = underTest.getAppUser(1L, mock(Model.class));
 
         assertEquals("pages/userpage", returnValue);
     }
@@ -55,9 +56,9 @@ class AppUserControllerTest {
     @Test
     void getAppUserThatIsNoAuthenticatedRedirects() {
         AppUser appUser = new AppUser(1L, "Joe Man", "1234", "joeman@mail.com", Role.CANDIDATE);
-        AppUserDetails appUserDetails = new AppUserDetails(appUser);
+        when(authService.getAuthenticatedUser()).thenReturn(appUser);
 
-        String returnValue = underTest.getAppUser(appUserDetails, appUser.getId(), mock(Model.class));
+        String returnValue = underTest.getAppUser(appUser.getId(), mock(Model.class));
         when(appUserService.getAppUser(appUser.getId())).thenReturn(Optional.of(appUser));
 
         assertEquals("redirect:/", returnValue);
@@ -66,10 +67,11 @@ class AppUserControllerTest {
     @Test
     void getAppUserThatDoesNotExistRedirects() {
         AppUser appUser = new AppUser(1L, "Joe Man", "1234", "joeman@mail.com", Role.CANDIDATE);
-        AppUserDetails appUserDetails = new AppUserDetails(appUser);
         SecurityUtilities.authenticateAnonymousUser();
+        when(authService.getAuthenticatedUser()).thenReturn(appUser);
+        when(authService.isUserAuthenticated()).thenReturn(true);
 
-        String returnValue = underTest.getAppUser(appUserDetails, appUser.getId(), mock(Model.class));
+        String returnValue = underTest.getAppUser(appUser.getId(), mock(Model.class));
         when(appUserService.getAppUser(appUser.getId())).thenReturn(Optional.empty());
 
         verify(appUserService).getAppUser(appUser.getId());
@@ -79,18 +81,21 @@ class AppUserControllerTest {
     @Test
     void getUsersLikeNameUserNotSignedIn() {
         AppUser loggedInAppUser = new AppUser(1L, "Joe Man", "1234", "joerecruiter@mail.com", Role.CANDIDATE);
-        AppUserDetails appUserDetails = new AppUserDetails(loggedInAppUser);
         SecurityContextHolder.clearContext();
-        String returnedPage = underTest.getUsersLikeName(appUserDetails,"name", mock(Model.class));
+        when(authService.getAuthenticatedUser()).thenReturn(loggedInAppUser);
+
+        String returnedPage = underTest.getUsersLikeName("name", mock(Model.class));
         assertEquals("redirect:/", returnedPage);
     }
 
     @Test
     void getUsersLikeNameUserSignedIn() {
         AppUser loggedInAppUser = new AppUser(1L, "Joe Man", "1234", "joerecruiter@mail.com", Role.CANDIDATE);
-        AppUserDetails appUserDetails = new AppUserDetails(loggedInAppUser);
         SecurityUtilities.authenticateAnonymousUser();
-        String returnedPage = underTest.getUsersLikeName(appUserDetails,"name", mock(Model.class));
+        when(authService.getAuthenticatedUser()).thenReturn(loggedInAppUser);
+        when(authService.isUserAuthenticated()).thenReturn(true);
+
+        String returnedPage = underTest.getUsersLikeName("name", mock(Model.class));
         assertEquals("pages/usersearchpage", returnedPage);
     }
 
@@ -112,8 +117,10 @@ class AppUserControllerTest {
     void isCompanyForSetCandidateToRecruiter() {
         AppUser companyUser = new AppUser(1L, "Joe Man", "1234", "joecompany@mail.com", Role.COMPANY);
         AppUser candidateUser = new AppUser(2L, "Joe Man", "1234", "joecandidate@mail.com", Role.CANDIDATE);
+        when(authService.getAuthenticatedUser()).thenReturn(companyUser);
+        when(authService.doesUserHaveRole(Role.COMPANY)).thenReturn(true);
 
-        String returnValue = underTest.markCandidateToRecruiter(candidateUser, companyUser);
+        String returnValue = underTest.markCandidateToRecruiter(candidateUser);
 
         assertEquals("pages/userpage", returnValue);
     }
@@ -122,8 +129,9 @@ class AppUserControllerTest {
     void isNotCompanyForSetCandidateToRecruiter() {
         AppUser notCompanyUser = new AppUser(1L, "Joe Man", "1234", "joerecruiter@mail.com", Role.RECRUITER);
         AppUser candidateUser = new AppUser(2L, "Joe Man", "1234", "joecandidate@mail.com", Role.CANDIDATE);
+        when(authService.getAuthenticatedUser()).thenReturn(notCompanyUser);
 
-        String returnValue = underTest.markCandidateToRecruiter(candidateUser, notCompanyUser);
+        String returnValue = underTest.markCandidateToRecruiter(candidateUser);
 
         assertEquals("You must be a company to mark candidates as recruiters.", returnValue);
     }
@@ -131,8 +139,10 @@ class AppUserControllerTest {
     void isCompanyForSetRecruiterToCandidate() {
         AppUser companyUser = new AppUser(1L, "Joe Man", "1234", "joecompany@mail.com", Role.COMPANY);
         AppUser recruiterUser = new AppUser(2L, "Joe Man", "1234", "joerecruiter@mail.com", Role.RECRUITER);
+        when(authService.getAuthenticatedUser()).thenReturn(companyUser);
+        when(authService.doesUserHaveRole(Role.COMPANY)).thenReturn(true);
 
-        String returnValue = underTest.unmarkRecruiterToCandidate(recruiterUser, companyUser);
+        String returnValue = underTest.unmarkRecruiterToCandidate(recruiterUser);
 
         assertEquals("pages/userpage", returnValue);
     }
@@ -141,8 +151,9 @@ class AppUserControllerTest {
     void isNotCompanyForSetRecruiterToCandidate() {
         AppUser notCompanyUser = new AppUser(1L, "Joe Man", "1234", "joerecruiter@mail.com", Role.RECRUITER);
         AppUser recruiterUser = new AppUser(2L, "Joe Man", "1234", "joecandidate@mail.com", Role.RECRUITER);
+        when(authService.getAuthenticatedUser()).thenReturn(notCompanyUser);
 
-        String returnValue = underTest.unmarkRecruiterToCandidate(recruiterUser, notCompanyUser);
+        String returnValue = underTest.unmarkRecruiterToCandidate(recruiterUser);
 
         assertEquals("You must be a company to unmark recruiters as candidates.", returnValue);
     }

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserTest.java
@@ -133,17 +133,6 @@ class AppUserTest {
     }
 
     @Test
-    void testIsUserAuthenticatedReturnsTrue() {
-        SecurityUtilities.authenticateAnonymousUser();
-        assertThat(AppUser.isUserAuthenticated()).isTrue();
-    }
-
-    @Test
-    void testIsUserAuthenticatedReturnsFalse() {
-        assertThat(AppUser.isUserAuthenticated()).isFalse();
-    }
-
-    @Test
     void recruiterGetCompanySucceeds() {
         underTest2 = new AppUser(id, name, password, email, Role.RECRUITER, authProvider);
         assertEquals(underTest2.getCompany(), underTest2.getCompany());

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AuthServiceTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AuthServiceTest.java
@@ -1,0 +1,54 @@
+package com.soen.synapsis.unit.appuser;
+
+import com.soen.synapsis.appuser.AppUser;
+import com.soen.synapsis.appuser.AuthService;
+import com.soen.synapsis.appuser.Role;
+import com.soen.synapsis.utilities.SecurityUtilities;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class AuthServiceTest {
+
+    private AuthService underTest;
+    @BeforeEach
+    void setUp() {
+        underTest = new AuthService();
+    }
+
+    @Test
+    void testIsUserAuthenticatedReturnsTrue() {
+        SecurityUtilities.authenticateAnonymousUser();
+        assertThat(underTest.isUserAuthenticated()).isTrue();
+    }
+
+    @Test
+    void testIsUserAuthenticatedReturnsFalse() {
+        SecurityUtilities.doNotAuthenticateAnonymousUser();
+        assertThat(underTest.isUserAuthenticated()).isFalse();
+    }
+
+    @Test
+    void getAuthenticatedUserThrowsOnUnauthedUser() {
+        SecurityUtilities.doNotAuthenticateAnonymousUser();
+
+        assertThrows(IllegalStateException.class,
+                () -> underTest.getAuthenticatedUser(), "User not registered");
+    }
+
+    @Test
+    void doesUserHaveRoleReturnsFalseOnUnauthedUser() {
+        SecurityUtilities.doNotAuthenticateAnonymousUser();
+
+        assertThat(underTest.doesUserHaveRole(Role.CANDIDATE)).isFalse();
+    }
+
+    @Test
+    void doesUserHaveMultipleRoleReturnsFalseOnUnauthedUser() {
+        SecurityUtilities.doNotAuthenticateAnonymousUser();
+
+        assertThat(underTest.doesUserHaveRole(Role.CANDIDATE, Role.RECRUITER)).isFalse();
+    }
+}

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/connection/ConnectionControllerTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/connection/ConnectionControllerTest.java
@@ -2,6 +2,7 @@ package com.soen.synapsis.unit.appuser.connection;
 
 import com.soen.synapsis.appuser.AppUser;
 import com.soen.synapsis.appuser.AppUserDetails;
+import com.soen.synapsis.appuser.AuthService;
 import com.soen.synapsis.appuser.Role;
 import com.soen.synapsis.appuser.connection.ConnectionController;
 import com.soen.synapsis.appuser.connection.ConnectionService;
@@ -16,17 +17,20 @@ import org.springframework.ui.Model;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ConnectionControllerTest {
     @Mock
     private ConnectionService connectionService;
+    @Mock
+    private AuthService authService;
     private ConnectionController underTest;
     private AutoCloseable autoCloseable;
 
     @BeforeEach
     void setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this);
-        underTest = new ConnectionController(connectionService);
+        underTest = new ConnectionController(connectionService, authService);
     }
 
     @AfterEach
@@ -38,10 +42,11 @@ public class ConnectionControllerTest {
     @Test
     void viewConnectionPage() {
         AppUser loggedInAppUser = new AppUser(1L, "Joe Man", "1234", "joerecruiter@mail.com", Role.CANDIDATE);
-        AppUserDetails appUserDetails = new AppUserDetails(loggedInAppUser);
         SecurityUtilities.authenticateAnonymousUser();
+        when(authService.isUserAuthenticated()).thenReturn(true);
+        when(authService.getAuthenticatedUser()).thenReturn(loggedInAppUser);
 
-        String returnedPage = underTest.viewNetwork(appUserDetails, mock(Model.class));
+        String returnedPage = underTest.viewNetwork(mock(Model.class));
 
         assertEquals("pages/network", returnedPage);
     }
@@ -49,10 +54,10 @@ public class ConnectionControllerTest {
     @Test
     void rejectConnectionRequestPage() {
         AppUser loggedInAppUser = new AppUser(1L, "Joe Man", "1234", "joerecruiter@mail.com", Role.CANDIDATE);
-        AppUserDetails appUserDetails = new AppUserDetails(loggedInAppUser);
         SecurityUtilities.authenticateAnonymousUser();
+        when(authService.getAuthenticatedUser()).thenReturn(loggedInAppUser);
 
-        String returnedPage = underTest.rejectConnection(appUserDetails, 2L, mock(Model.class));
+        String returnedPage = underTest.rejectConnection(2L, mock(Model.class));
 
         assertEquals(null, returnedPage);
     }
@@ -60,10 +65,10 @@ public class ConnectionControllerTest {
     @Test
     void acceptConnectionRequest() {
         AppUser loggedInAppUser = new AppUser(1L, "Joe Man", "1234", "joerecruiter@mail.com", Role.CANDIDATE);
-        AppUserDetails appUserDetails = new AppUserDetails(loggedInAppUser);
         SecurityUtilities.authenticateAnonymousUser();
+        when(authService.getAuthenticatedUser()).thenReturn(loggedInAppUser);
 
-        String returnedPage = underTest.acceptConnection(appUserDetails, 3L, mock(Model.class));
+        String returnedPage = underTest.acceptConnection(3L, mock(Model.class));
 
         assertEquals(null, returnedPage);
     }
@@ -82,9 +87,9 @@ public class ConnectionControllerTest {
     @Test
     void disconnectFromUser() {
         AppUser appUser = new AppUser("Joe Man", "1234", "joeman@email.com", Role.CANDIDATE);
-        AppUserDetails appUserDetails = new AppUserDetails(appUser);
+        when(authService.getAuthenticatedUser()).thenReturn(appUser);
 
-        String returnedPage = underTest.disconnectFromUser(appUserDetails,2L);
+        String returnedPage = underTest.disconnectFromUser(2L);
 
         assertEquals("redirect:/user/2", returnedPage);
     }

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/connection/ConnectionServiceTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/connection/ConnectionServiceTest.java
@@ -120,7 +120,6 @@ public class ConnectionServiceTest {
 
     @Test
     void getConnections() {
-        AppUserDetails appUserDetails = new AppUserDetails(candidateUser1);
         ConnectionKey connectionKey = new ConnectionKey(candidateUser1.getId(), candidateUser2.getId());
         Connection connection = new Connection(connectionKey, candidateUser1, candidateUser2, false);
 
@@ -132,7 +131,7 @@ public class ConnectionServiceTest {
         given(connectionRepository.findAcceptedConnectionsByRequesterID(Mockito.any(Long.class))).willReturn(allConnectionsIDs);
         given(appUserRepository.getReferenceById(Mockito.any(Long.class))).willReturn(candidateUser2);
 
-        List<AppUser> returnValue = underTest.getConnections(appUserDetails);
+        List<AppUser> returnValue = underTest.getConnections(candidateUser1);
 
         verify(connectionRepository).findAcceptedConnectionsByRequesterID(candidateUser1.getId());
         verify(connectionRepository).findAcceptedConnectionsByReceiverID(candidateUser1.getId());
@@ -142,11 +141,10 @@ public class ConnectionServiceTest {
 
     @Test
     void rejectConnectionWithNonExistentConnection() {
-        AppUserDetails appUserDetails = new AppUserDetails(candidateUser1);
         ArgumentCaptor<ConnectionKey> connectionArgumentCaptor = ArgumentCaptor.forClass(ConnectionKey.class);
         verify(connectionRepository, never()).deleteById(connectionArgumentCaptor.capture());
 
-        assertThrows(IllegalStateException.class, () -> underTest.rejectConnection(appUserDetails, candidateUser2.getId()));
+        assertThrows(IllegalStateException.class, () -> underTest.rejectConnection(candidateUser1, candidateUser2.getId()));
     }
 
     @Test
@@ -158,8 +156,7 @@ public class ConnectionServiceTest {
         ArgumentCaptor<ConnectionKey> connectionArgumentCaptor = ArgumentCaptor.forClass(ConnectionKey.class);
         verify(connectionRepository, never()).deleteById(connectionArgumentCaptor.capture());
 
-        AppUserDetails appUserDetails = new AppUserDetails(candidateUser1);
-        assertThrows(IllegalStateException.class, () -> underTest.rejectConnection(appUserDetails, candidateUser2.getId()));
+        assertThrows(IllegalStateException.class, () -> underTest.rejectConnection(candidateUser1, candidateUser2.getId()));
     }
 
     @Test
@@ -171,17 +168,15 @@ public class ConnectionServiceTest {
         ArgumentCaptor<ConnectionKey> connectionArgumentCaptor = ArgumentCaptor.forClass(ConnectionKey.class);
         verify(connectionRepository, atMostOnce()).deleteById(connectionArgumentCaptor.capture());
 
-        AppUserDetails appUserDetails = new AppUserDetails(candidateUser1);
-        assertEquals(underTest.rejectConnection(appUserDetails, candidateUser2.getId()), "redirect:/network");
+        assertEquals(underTest.rejectConnection(candidateUser1, candidateUser2.getId()), "redirect:/network");
     }
 
     @Test
     void acceptConnectionWithNonExistentConnection() {
-        AppUserDetails appUserDetails = new AppUserDetails(candidateUser1);
         ArgumentCaptor<ConnectionKey> connectionArgumentCaptor = ArgumentCaptor.forClass(ConnectionKey.class);
         verify(connectionRepository, never()).deleteById(connectionArgumentCaptor.capture());
 
-        assertThrows(IllegalStateException.class, () -> underTest.acceptConnection(appUserDetails, candidateUser2.getId()));
+        assertThrows(IllegalStateException.class, () -> underTest.acceptConnection(candidateUser1, candidateUser2.getId()));
     }
 
     @Test
@@ -193,8 +188,7 @@ public class ConnectionServiceTest {
         ArgumentCaptor<ConnectionKey> connectionArgumentCaptor = ArgumentCaptor.forClass(ConnectionKey.class);
         verify(connectionRepository, never()).deleteById(connectionArgumentCaptor.capture());
 
-        AppUserDetails appUserDetails = new AppUserDetails(candidateUser1);
-        assertThrows(IllegalStateException.class, () -> underTest.acceptConnection(appUserDetails, candidateUser2.getId()));
+        assertThrows(IllegalStateException.class, () -> underTest.acceptConnection(candidateUser1, candidateUser2.getId()));
     }
 
     @Test
@@ -206,8 +200,7 @@ public class ConnectionServiceTest {
         ArgumentCaptor<ConnectionKey> connectionArgumentCaptor = ArgumentCaptor.forClass(ConnectionKey.class);
         verify(connectionRepository, atMostOnce()).deleteById(connectionArgumentCaptor.capture());
 
-        AppUserDetails appUserDetails = new AppUserDetails(candidateUser1);
-        assertEquals(underTest.acceptConnection(appUserDetails, candidateUser2.getId()), "redirect:/network");
+        assertEquals(underTest.acceptConnection(candidateUser1, candidateUser2.getId()), "redirect:/network");
     }
 
     @Test

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/job/JobControllerTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/job/JobControllerTest.java
@@ -21,14 +21,14 @@ class JobControllerTest {
     @Mock
     private JobService jobService;
     @Mock
-    private AppUserService appUserService;
+    private AuthService authService;
     private AutoCloseable autoCloseable;
     private JobController underTest;
 
     @BeforeEach
     void setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this);
-        underTest = new JobController(jobService, appUserService);
+        underTest = new JobController(jobService, authService);
     }
 
     @AfterEach
@@ -60,7 +60,9 @@ class JobControllerTest {
         JobRequest request = new JobRequest("Software Engineer", "Synapsis", "1 Synapsis Street, Montreal, QC, Canada", "Sample Description", JobType.FULLTIME, 1);
         AppUser creator = new AppUser(10L, "joe", "1234", "joeunittest@mail.com", Role.RECRUITER, AuthProvider.LOCAL);
         request.setCreator(creator);
-        underTest.createJob(request, mock(BindingResult.class), mock(Model.class), mock(AppUserDetails.class));
+        when(authService.getAuthenticatedUser()).thenReturn(creator);
+
+        underTest.createJob(request, mock(BindingResult.class), mock(Model.class));
         verify(jobService).createJob(request);
     }
 
@@ -70,11 +72,12 @@ class JobControllerTest {
         AppUser creator = new AppUser(10L, "joe", "1234", "joeunittest@mail.com", Role.RECRUITER, AuthProvider.LOCAL);
         request.setCreator(creator);
         Model model = mock(Model.class);
+        when(authService.getAuthenticatedUser()).thenReturn(creator);
 
         BindingResult bindingResult = mock(BindingResult.class);
         when(bindingResult.hasErrors()).thenReturn(true);
 
-        underTest.createJob(request, bindingResult, model, mock(AppUserDetails.class));
+        underTest.createJob(request, bindingResult, model);
 
         verify(model).addAttribute(anyString(), anyString());
     }

--- a/synapsis/src/test/java/com/soen/synapsis/utilities/SecurityUtilities.java
+++ b/synapsis/src/test/java/com/soen/synapsis/utilities/SecurityUtilities.java
@@ -7,4 +7,8 @@ public class SecurityUtilities {
     public static void authenticateAnonymousUser() {
         SecurityContextHolder.getContext().setAuthentication(new TestingAuthenticationToken("TEST_USER", "credentials", "authority"));
     }
+
+    public static void doNotAuthenticateAnonymousUser() {
+        SecurityContextHolder.clearContext();
+    }
 }


### PR DESCRIPTION
Create AuthService, through which controller methods can verify the user's authentication status and properties without directly accessing an authentication principle, as well as allowing simpler mocking in tests. Modify existing control methods to use the AuthService, as well as associated tests.

This PR closes #102 