### PR TITLE
#149 Link the 'more details' button to its specific job page

### DIFF
--- a/synapsis/src/main/resources/templates/pages/jobs.html
+++ b/synapsis/src/main/resources/templates/pages/jobs.html
@@ -22,7 +22,8 @@
           <div class="bg-light-blue mx-auto w-11/12 rounded-2xl text-xs mt-2">
             <div class="font-sans font-light p-2" th:text="${job.description}"></div>
             <p class="px-2">Salary: TBD</p>
-            <button class="p-2 underline">More details</button>
+            <a th:href="@{/job/{id}(id=${job.getID()})}" class="inline-block px-4 py-2 underline">More details</a>
+
           </div>
 
           <div class="ml-4 mr-4 mt-6 flex justify-center">


### PR DESCRIPTION
Fix the "more details" button in Jobs page to redirect to its job page