### PR TITLE
#216 Allow admins to ban or warn reported users

### DIFF
--- a/synapsis/src/main/java/com/soen/synapsis/appuser/AppUser.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/AppUser.java
@@ -50,6 +50,8 @@ public class AppUser {
     @Enumerated(EnumType.STRING)
     private AuthProvider authProvider;
 
+    @Column
+    private Boolean isBanned;
 
     @ManyToOne
     @JoinColumn(name = "company_id")
@@ -83,6 +85,19 @@ public class AppUser {
         this.securityAnswer1 = securityAnswer1;
         this.securityAnswer2 = securityAnswer2;
         this.securityAnswer3 = securityAnswer3;
+    }
+
+    public AppUser(Long id, String name, String password, String email, Role role, AuthProvider authProvider, String securityAnswer1, String securityAnswer2, String securityAnswer3, Boolean isBanned) {
+        this.id = id;
+        this.name = name;
+        this.password = password;
+        this.email = email;
+        this.role = role;
+        this.authProvider = authProvider;
+        this.securityAnswer1 = securityAnswer1;
+        this.securityAnswer2 = securityAnswer2;
+        this.securityAnswer3 = securityAnswer3;
+        this.isBanned = isBanned;
     }
 
     public AppUser(Long id, String name, String password, String email, Role role, AuthProvider authProvider) {
@@ -177,6 +192,14 @@ public class AppUser {
 
     public void setRole(Role role) {
         this.role = role;
+    }
+
+    public Boolean getIsBanned() {
+        return isBanned;
+    }
+
+    public void setIsBanned(Boolean isBanned) {
+        this.isBanned = isBanned;
     }
 
     public boolean getVerificationStatus() {

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/AppUserController.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/AppUserController.java
@@ -3,6 +3,7 @@ package com.soen.synapsis.appuser;
 import com.soen.synapsis.appuser.connection.ConnectionService;
 import com.soen.synapsis.appuser.profile.appuserprofile.AppUserProfile;
 import com.soen.synapsis.appuser.profile.companyprofile.CompanyProfile;
+import com.soen.synapsis.websockets.chat.ChatService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
@@ -23,18 +24,21 @@ public class AppUserController {
     private final AppUserService appUserService;
     private final ConnectionService connectionService;
     private final AuthService authService;
+    private final ChatService chatService;
 
     @Autowired
-    public AppUserController(AppUserService appUserService, ConnectionService connectionService) {
+    public AppUserController(AppUserService appUserService, ConnectionService connectionService, ChatService chatService) {
         this.appUserService = appUserService;
         this.connectionService = connectionService;
         this.authService = new AuthService();
+        this.chatService = chatService;
     }
 
-    public AppUserController(AppUserService appUserService, ConnectionService connectionService, AuthService authService) {
+    public AppUserController(AppUserService appUserService, ConnectionService connectionService, AuthService authService, ChatService chatService) {
         this.appUserService = appUserService;
         this.connectionService = connectionService;
         this.authService = authService;
+        this.chatService = chatService;
     }
 
     /**
@@ -309,5 +313,26 @@ public class AppUserController {
         catch (IllegalStateException e) {
             return "redirect:/";
         }
+    }
+
+    /**
+     * Bans a user if the admin has determined they have sent a message
+     * that is not allowed
+     * @param senderId The ID of the user to be banned
+     * @return Chats page, so admin can continue monitoring chat reports
+     */
+    @PostMapping("/user/banUser")
+    public String banUser(@RequestParam("senderId") Long senderId, @RequestParam("messageId") Long messageId) {
+        if (!authService.doesUserHaveRole(Role.ADMIN)) {
+            return "redirect:/";
+        }
+
+        boolean appUserBanned = appUserService.banUser(senderId);
+
+        if (appUserBanned) {
+            chatService.resolveReport(messageId);
+        }
+
+        return "redirect:/chats";
     }
 }

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/AppUserDetails.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/AppUserDetails.java
@@ -79,11 +79,14 @@ public class AppUserDetails implements UserDetails, AppUserAuth {
     /**
      * Verifies if account is enabled for use.
      * Used by authentication framework.
-     * @return Always returns true.
+     * @return The opposite of the user's isBanned value.
      */
     @Override
     public boolean isEnabled() {
-        return true;
+        if (appUser.getIsBanned() == null)
+            return true;
+
+        return !appUser.getIsBanned();
     }
 
     public Role getRole() {

--- a/synapsis/src/main/java/com/soen/synapsis/appuser/AppUserService.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/AppUserService.java
@@ -238,4 +238,24 @@ public class AppUserService {
         appUserRepository.save(appUser);
 
     }
+
+    /**
+     * Ban user from site, so they can no longer log-in
+     * @param appUserId The ID of the user to ban
+     * @return true if the user was successfully banned, false otherwise
+     */
+    public boolean banUser(Long appUserId) {
+        Optional<AppUser> optionalAppUser = getAppUser(appUserId);
+
+        if (optionalAppUser.isEmpty()) {
+            return false;
+        }
+
+        AppUser appUser = optionalAppUser.get();
+
+        appUser.setIsBanned(true);
+        appUserRepository.save(appUser);
+
+        return true;
+    }
 }

--- a/synapsis/src/main/java/com/soen/synapsis/websockets/chat/ChatController.java
+++ b/synapsis/src/main/java/com/soen/synapsis/websockets/chat/ChatController.java
@@ -251,4 +251,37 @@ public class ChatController {
         model.addAttribute("listOfListOfMessages", reportedMessage);
         return "pages/adminMessagesPage";
     }
+
+    /**
+     * Ignores the user report of a message and takes no action
+     * @param messageId The ID of the reported message
+     * @return View of admin chats page
+     */
+    @PostMapping("/chats/ignore")
+    public String ignoreReport(@RequestParam("messageId") Long messageId) {
+        if (!authService.doesUserHaveRole(Role.ADMIN)) {
+            return "redirect:/";
+        }
+
+        chatService.resolveReport(messageId);
+
+        return "redirect:/chats";
+    }
+
+    /**
+     * Brings the admin to the chat page with the reported user so a warning can be written
+     * @param senderId The reported user ID
+     * @param messageId The reported message ID
+     * @return View of the chat page with the reported user
+     */
+    @PostMapping("/chats/warnUser")
+    public String warnUser(@RequestParam("senderId") Long senderId, @RequestParam("messageId") Long messageId) {
+        if (!authService.doesUserHaveRole(Role.ADMIN)) {
+            return "redirect:/";
+        }
+
+        chatService.resolveReport(messageId);
+
+        return chatService.createChat(authService.getAuthenticatedUser(), senderId);
+    }
 }

--- a/synapsis/src/main/java/com/soen/synapsis/websockets/chat/ChatService.java
+++ b/synapsis/src/main/java/com/soen/synapsis/websockets/chat/ChatService.java
@@ -126,4 +126,12 @@ public class ChatService {
     public List<List<Message>> getReportedMessages() {
         return messageService.getReportedMessages();
     }
+
+    /**
+     * Marks a message that was reported as resolved.
+     * @param messageId the message to mark as resolved.
+     */
+    public void resolveReport(Long messageId) {
+        messageService.resolveReport(messageId);
+    }
 }

--- a/synapsis/src/main/java/com/soen/synapsis/websockets/chat/message/MessageService.java
+++ b/synapsis/src/main/java/com/soen/synapsis/websockets/chat/message/MessageService.java
@@ -110,4 +110,21 @@ public class MessageService {
 
         return result;
     }
+
+    /**
+     * Marks a message that was reported as resolved.
+     * @param messageId the message to mark as resolved.
+     */
+    public void resolveReport(Long messageId) {
+        Optional<Message> optionalReportedMessage = messageRepository.findById(messageId);
+
+        if (optionalReportedMessage.isEmpty()) {
+            return;
+        }
+
+        Message reportedMessage = optionalReportedMessage.get();
+
+        reportedMessage.setReportStatus(ReportStatus.REVIEWED);
+        messageRepository.save(reportedMessage);
+    }
 }

--- a/synapsis/src/main/resources/templates/pages/adminMessagesPage.html
+++ b/synapsis/src/main/resources/templates/pages/adminMessagesPage.html
@@ -5,11 +5,41 @@
         <div th:each="message: ${messageList}">
             <th:block th:if="${message.fileName != null and message.file != null}">
                 <img th:if="${message.fileName.toLowerCase().matches('.*\.(png|jpe?g|gif|bmp)')}" th:src="${message.file}" th:alt="${message.fileName}" />
-                <a th:unless="${message.fileName.toLowerCase().matches('.*\.(png|jpe?g|gif|bmp)')}" th:download="${message.fileName}" th:text="'Download' + ${message.fileName}"></a>
+                <a th:unless="${message.fileName.toLowerCase().matches('.*\.(png|jpe?g|gif|bmp)')}" th:download="${message.fileName}" th:text="'Download ' + ${message.fileName}"></a>
             </th:block>
             <p th:text="${message.content}" th:class="${messageList.indexOf(message) + 1 == messageList.size()} ? 'text-red-600'" ></p>
         </div>
-        <button class="btn bg-black btn-black font-sans text-sm w-20 h-9 p-0">Warn</button>
-        <button class="btn bg-primary btn-primary font-sans text-sm w-20 h-9 p-0">Ban</button>
+
+        <!-- Button to warn user -->
+        <form th:action="@{/chats/warnUser}" method="post">
+            <div th:each="message: ${messageList}">
+                <div th:if="${messageList.indexOf(message) + 1 == messageList.size()}">
+                    <input type="number" name="senderId" th:value="${message.sender.id}" hidden>
+                    <input type="number" name="messageId" th:value="${message.id}" hidden>
+                </div>
+            </div>
+            <button class="btn bg-black btn-black font-sans text-sm w-20 h-9 p-0">Warn</button>
+        </form>
+
+        <!-- Button to ban user -->
+        <form th:action="@{/user/banUser}" method="post">
+            <div th:each="message: ${messageList}">
+                <div th:if="${messageList.indexOf(message) + 1 == messageList.size()}">
+                    <input type="number" name="senderId" th:value="${message.sender.id}" hidden>
+                    <input type="number" name="messageId" th:value="${message.id}" hidden>
+                </div>
+            </div>
+            <button type="submit" class="btn bg-primary btn-primary font-sans text-sm w-20 h-9 p-0">Ban</button>
+        </form>
+
+        <!-- Button to ignore report -->
+        <form th:action="@{/chats/ignore}" method="post">
+            <div th:each="message: ${messageList}">
+                <div th:if="${messageList.indexOf(message) + 1 == messageList.size()}">
+                    <input type="number" name="messageId" th:value="${message.id}" hidden>
+                </div>
+            </div>
+            <button type="submit" class="btn btn-secondary font-sans text-sm w-20 h-9 p-0">Ignore</button>
+        </form>
     </div>
 </div>

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserDetailsTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserDetailsTest.java
@@ -68,7 +68,14 @@ public class AppUserDetailsTest {
     }
 
     @Test
-    void isEnabledReturnsTrue() {
+    void isEnabledReturnsTrueOnNullIsBanned() {
+        underTest.getAppUser().setIsBanned(null);
+        assertTrue(underTest.isEnabled());
+    }
+
+    @Test
+    void isEnabledReturnsTrueOnFalseIsBanned() {
+        underTest.getAppUser().setIsBanned(false);
         assertTrue(underTest.isEnabled());
     }
 

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserServiceTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserServiceTest.java
@@ -240,4 +240,26 @@ public class AppUserServiceTest {
         assertEquals(false, companyUser.getVerificationStatus());
         verify(appUserRepository).save(companyUser);
     }
+
+    @Test
+    void banUserThatIsNotFoundReturnsFalse() {
+        Long id = 1L;
+        when(appUserRepository.findById(id)).thenReturn(Optional.empty());
+
+        Boolean returnValue = underTest.banUser(id);
+
+        assertEquals(false, returnValue);
+    }
+
+    @Test
+    void banUserThatIsFoundReturnsTrue() {
+        Long id = 1L;
+        AppUser appUser = new AppUser("Joe Man", "1234", "email@mail.com", Role.CANDIDATE);
+        when(appUserRepository.findById(id)).thenReturn(Optional.of(appUser));
+
+        Boolean returnValue = underTest.banUser(id);
+
+        assertEquals(true, appUser.getIsBanned());
+        assertEquals(true, returnValue);
+    }
 }

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/AppUserTest.java
@@ -24,6 +24,7 @@ class AppUserTest {
     private String password;
     private String email;
     private Role role;
+    private Boolean isBanned;
     private AuthProvider authProvider;
     private String securityAnswer1;
     private String securityAnswer2;
@@ -36,11 +37,12 @@ class AppUserTest {
         password = "1234";
         email = "joeunittest@mail.com";
         role = Role.CANDIDATE;
+        isBanned = false;
         authProvider = AuthProvider.LOCAL;
         securityAnswer1 = "a";
         securityAnswer2 = "a";
         securityAnswer3 = "a";
-        underTest = new AppUser(id, name, password, email, role, authProvider, securityAnswer1, securityAnswer2, securityAnswer3);
+        underTest = new AppUser(id, name, password, email, role, authProvider, securityAnswer1, securityAnswer2, securityAnswer3, isBanned);
     }
 
     @AfterEach
@@ -118,6 +120,19 @@ class AppUserTest {
         assertEquals(newRole, underTest.getRole());
     }
 
+    @Test
+    void getIsBanned() {
+        assertEquals(isBanned, underTest.getIsBanned());
+    }
+
+    @Test
+    void setIsBanned() {
+        Boolean newIsBanned = true;
+
+        underTest.setIsBanned(newIsBanned);
+
+        assertEquals(newIsBanned, underTest.getIsBanned());
+    }
 
     @Test
     void getAuthProvider() {

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/job/JobApplicationTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/job/JobApplicationTest.java
@@ -186,16 +186,20 @@ public class JobApplicationTest {
     void getResume() { assertEquals(resume, underTest.getResume()); }
 
     @Test
-    @Disabled
     void setResume() {
+        String newResume = "1234";
+        underTest.setResume(newResume);
+        assertEquals(newResume, underTest.getResume());
     }
 
     @Test
     void getCoverLetter() { assertEquals(coverLetter, underTest.getCoverLetter()); }
 
     @Test
-    @Disabled
     void setCoverLetter() {
+        String newCoverLetter = "1234";
+        underTest.setCoverLetter(newCoverLetter);
+        assertEquals(newCoverLetter, underTest.getCoverLetter());
     }
 
     @Test

--- a/synapsis/src/test/java/com/soen/synapsis/unit/appuser/profile/userprofiletest/UpdateAppUserProfileControllerTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/appuser/profile/userprofiletest/UpdateAppUserProfileControllerTest.java
@@ -2,6 +2,7 @@ package com.soen.synapsis.unit.appuser.profile.userprofiletest;
 
 import com.soen.synapsis.appuser.AppUser;
 import com.soen.synapsis.appuser.AppUserService;
+import com.soen.synapsis.appuser.AuthService;
 import com.soen.synapsis.appuser.Role;
 import com.soen.synapsis.appuser.profile.appuserprofile.updateprofile.UpdateAppUserProfileController;
 import com.soen.synapsis.appuser.profile.appuserprofile.updateprofile.UpdateAppUserProfileRequest;
@@ -27,6 +28,8 @@ class UpdateAppUserProfileControllerTest {
     private UpdateAppUserProfileService updateAppUserProfileService;
     @Mock
     AppUserService appUserService;
+    @Mock
+    AuthService authService;
 
     private AutoCloseable autoCloseable;
     private UpdateAppUserProfileController underTest;
@@ -34,7 +37,7 @@ class UpdateAppUserProfileControllerTest {
     @BeforeEach
     void setUp() {
         autoCloseable = MockitoAnnotations.openMocks(this);
-        underTest = new UpdateAppUserProfileController(updateAppUserProfileService, appUserService);
+        underTest = new UpdateAppUserProfileController(updateAppUserProfileService, authService, appUserService);
     }
 
     @AfterEach
@@ -44,6 +47,7 @@ class UpdateAppUserProfileControllerTest {
 
     @Test
     void viewUpdateAppUserPage() {
+        when(authService.doesUserHaveRole(Role.CANDIDATE, Role.RECRUITER)).thenReturn(false);
         String returnedPage = underTest.updateAppUserProfile(Mockito.mock(Model.class));
         assertEquals("redirect:/", returnedPage);
     }

--- a/synapsis/src/test/java/com/soen/synapsis/unit/websockets/chat/ChatControllerTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/websockets/chat/ChatControllerTest.java
@@ -399,4 +399,53 @@ class ChatControllerTest {
         when(authService.doesUserHaveRole(Role.ADMIN)).thenReturn(true);
         assertEquals("pages/adminMessagesPage", underTest.getReportMessage(Mockito.mock(Model.class)));
     }
+
+    @Test
+    void ignoreReportWithoutAdminRedirects() {
+        String redirect = "redirect:/";
+
+        when(authService.doesUserHaveRole(Role.ADMIN)).thenReturn(false);
+
+        String returnValue = underTest.ignoreReport(1L);
+
+        assertEquals(redirect, returnValue);
+    }
+
+    @Test
+    void ignoreReportResolves() {
+        String redirect = "redirect:/chats";
+        Long messageId = 1L;
+
+        when(authService.doesUserHaveRole(Role.ADMIN)).thenReturn(true);
+
+        String returnValue = underTest.ignoreReport(messageId);
+
+        verify(chatService, times(1)).resolveReport(messageId);
+        assertEquals(redirect, returnValue);
+    }
+
+    @Test
+    void warnUserWithoutAdminRedirects() {
+        String redirect = "redirect:/";
+
+        when(authService.doesUserHaveRole(Role.ADMIN)).thenReturn(false);
+
+        String returnValue = underTest.warnUser(1L, 1L);
+
+        assertEquals(redirect, returnValue);
+    }
+
+    @Test
+    void warnUserResolvesAndCreatesChat() {
+        Long senderId = 1L;
+        Long messageId = 1L;
+
+        when(authService.doesUserHaveRole(Role.ADMIN)).thenReturn(true);
+        when(authService.getAuthenticatedUser()).thenReturn(user1);
+
+        underTest.warnUser(senderId, messageId);
+
+        verify(chatService, times(1)).resolveReport(messageId);
+        verify(chatService, times(1)).createChat(user1, senderId);
+    }
 }

--- a/synapsis/src/test/java/com/soen/synapsis/unit/websockets/chat/ChatServiceTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/websockets/chat/ChatServiceTest.java
@@ -20,8 +20,7 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 class ChatServiceTest {
 
@@ -119,5 +118,14 @@ class ChatServiceTest {
     void getReportedMessagesCallsTheMethodInMessageService() {
         underTest.getReportedMessages();
         verify(messageService).getReportedMessages();
+    }
+
+    @Test
+    void resolveReportCallsMessageService() {
+        Long messageId = 1L;
+
+        underTest.resolveReport(messageId);
+
+        verify(messageService, times(1)).resolveReport(messageId);
     }
 }

--- a/synapsis/src/test/java/com/soen/synapsis/unit/websockets/chat/message/MessageServiceTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/unit/websockets/chat/message/MessageServiceTest.java
@@ -132,4 +132,27 @@ class MessageServiceTest {
         assertEquals(result.size(), 1);
         assertEquals(result.get(0).size(), 5);
     }
+
+    @Test
+    void resolveReportOnUnfoundMessageReturns() {
+        Long messageId = 1L;
+        when(messageRepository.findById(messageId)).thenReturn(Optional.empty());
+
+        underTest.resolveReport(messageId);
+
+        verify(messageRepository, times(1)).findById(messageId);
+    }
+
+    @Test
+    void resolveReportMarksMessageReviewed() {
+        Long messageId = 1L;
+        Message message = new Message(messageId, chat, "message 1", sender, false, ReportStatus.REPORTED, new Timestamp(System.currentTimeMillis()));
+
+        when(messageRepository.findById(messageId)).thenReturn(Optional.of(message));
+
+        underTest.resolveReport(messageId);
+
+        assertEquals(ReportStatus.REVIEWED, message.getReportStatus());
+        verify(messageRepository, times(1)).save(message);
+    }
 }


### PR DESCRIPTION
On the reported messages page, admins now have the option to ban users, warn them, or ignore the report. Banned users will no longer be able to log in to their account, with an error message appearing when they attempt to do so.

This PR closes #216