### PR TITLE
#236 Remove Connection between an admin and a regular user

### DIFF
--- a/synapsis/src/main/resources/data.sql
+++ b/synapsis/src/main/resources/data.sql
@@ -31,9 +31,6 @@ VALUES ('Tony Recruiter', '$2a$12$ShsRhBqy8y9ep/oxB5ury.7cxmcGjt.BQA4i6dhp/RUva/
         'RECRUITER', 'LOCAL', false);
 
 INSERT INTO connection (receiver_id, requester_id, pending)
-VALUES (1, 2, false);
-
-INSERT INTO connection (receiver_id, requester_id, pending)
 VALUES (3, 1, false);
 
 INSERT INTO connection (receiver_id, requester_id, pending)


### PR DESCRIPTION
The data.sql file contains a connection between a regular user and an admin which is not allowed.

This PR closes: #236 