### PR TITLE
#259 add 404 page

### DIFF
--- a/synapsis/src/main/resources/templates/error/404.html
+++ b/synapsis/src/main/resources/templates/error/404.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html xmlns:layout="https://www.ultraq.net.nz/thymeleaf/layout" xmlns:sec="http://www.w3.org/1999/xhtml"
+      layout:decorate="_layout">
+<div layout:fragment="content">
+    <div class="flex flex-col items-center justify-center">
+        <div class="langEN text-3xl lg:text-6xl text-black font-medium font-serif">404 Error</div>
+        <div class="langFR text-3xl lg:text-6xl text-black font-medium font-serif">Erreur 404</div>
+
+        <div class="langEN text-lg md:text-xl lg:text-2xl text-grey font-normal mt-8 lg:mt-16">It seems that page does not exist...</div>
+        <div class="langFR text-lg md:text-xl lg:text-2xl text-grey font-normal mt-8 lg:mt-16">Il semblerait que cette page n'existe pas...</div>
+
+        <a href="/" class="langEN text-xl lg:text-2xl btn btn-primary mt-8 ml-6">Return Home</a>
+        <a href="/" class="langFR text-xl lg:text-2xl btn btn-primary mt-8 ml-6">Revenir à la page d'accueil</a>
+    </div>
+</div>
+</html>


### PR DESCRIPTION
Add a 404 page for requested resources that could not be found. The page is responsive and available in both English and French. A visualization can be viewed below.

This PR closes #259 

![image](https://user-images.githubusercontent.com/56362880/229642520-e2e95a36-3686-469e-97fd-aac1b1a9e9ef.png)
