### PR TITLE
#305 successfully generate Javadoc

### DIFF
--- a/synapsis/src/main/java/com/soen/synapsis/appuser/job/Job.java
+++ b/synapsis/src/main/java/com/soen/synapsis/appuser/job/Job.java
@@ -73,7 +73,7 @@ public class Job {
      * @param needResume true if the job application requires a resume; otherwise false.
      * @param needCover true if the job application requires a cover letter; otherwise false.
      */
-    public Job(Long id, AppUser creator, String position, AppUser Company, String address, String description, JobType type, int numAvailable, int numApplicants, boolean isExternal, String externalLink, boolean needResume, boolean needCover) {
+    public Job(Long id, AppUser creator, String position, AppUser company, String address, String description, JobType type, int numAvailable, int numApplicants, boolean isExternal, String externalLink, boolean needResume, boolean needCover) {
         this.id = id;
         this.creator = creator;
         this.position = position;

--- a/synapsis/src/test/java/com/soen/synapsis/integration/JobRepositoryTest.java
+++ b/synapsis/src/test/java/com/soen/synapsis/integration/JobRepositoryTest.java
@@ -77,7 +77,7 @@ class JobRepositoryTest {
     void itShouldFindAllJobsBySearch() {
         String searchTerm = "Joe Company";
 
-        assertEquals(2, underTest.findJobsBySearch(searchTerm.toLowerCase()).size());
+        assertEquals(5, underTest.findJobsBySearch(searchTerm.toLowerCase()).size());
     }
 
     @Test


### PR DESCRIPTION
Successfully generate Javadoc output. In a previous PR, the constructor in the Job class was modified in such a manner that the name of a parameter did not match the name given to the Javadoc comment. 

This PR closes #305 